### PR TITLE
feat: grocery price dashboard (price history, products, data quality)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "frontend",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--dir", "frontend", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -22,7 +22,8 @@ useSeoMeta({
         <UNavigationMenu
           :items="[
             { label: 'Price History', to: '/prices', icon: 'i-lucide-trending-up' },
-            { label: 'Products', to: '/products', icon: 'i-lucide-table' }
+            { label: 'Products', to: '/products', icon: 'i-lucide-table' },
+            { label: 'Data Quality', to: '/data-quality', icon: 'i-lucide-shield-alert' }
           ]"
           class="ml-4"
         />

--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -1,27 +1,13 @@
 <script setup>
 useHead({
-  meta: [
-    { name: 'viewport', content: 'width=device-width, initial-scale=1' }
-  ],
-  link: [
-    { rel: 'icon', href: '/favicon.ico' }
-  ],
-  htmlAttrs: {
-    lang: 'en'
-  }
+  meta: [{ name: 'viewport', content: 'width=device-width, initial-scale=1' }],
+  link: [{ rel: 'icon', href: '/favicon.ico' }],
+  htmlAttrs: { lang: 'en' }
 })
 
-const title = 'Nuxt Starter Template'
-const description = 'A production-ready starter template powered by Nuxt UI. Build beautiful, accessible, and performant applications in minutes, not hours.'
-
 useSeoMeta({
-  title,
-  description,
-  ogTitle: title,
-  ogDescription: description,
-  ogImage: 'https://ui.nuxt.com/assets/templates/nuxt/starter-light.png',
-  twitterImage: 'https://ui.nuxt.com/assets/templates/nuxt/starter-light.png',
-  twitterCard: 'summary_large_image'
+  title: 'cartwatch',
+  description: 'Track your grocery prices over time.'
 })
 </script>
 
@@ -29,24 +15,20 @@ useSeoMeta({
   <UApp>
     <UHeader>
       <template #left>
-        <NuxtLink to="/">
+        <NuxtLink to="/" class="flex items-center gap-2 font-semibold text-lg">
           <AppLogo class="w-auto h-6 shrink-0" />
         </NuxtLink>
 
-        <TemplateMenu />
+        <UNavigationMenu
+          :items="[
+            { label: 'Price History', to: '/prices', icon: 'i-lucide-trending-up' }
+          ]"
+          class="ml-4"
+        />
       </template>
 
       <template #right>
         <UColorModeButton />
-
-        <UButton
-          to="https://github.com/nuxt-ui-templates/starter"
-          target="_blank"
-          icon="i-simple-icons-github"
-          aria-label="GitHub"
-          color="neutral"
-          variant="ghost"
-        />
       </template>
     </UHeader>
 
@@ -54,24 +36,11 @@ useSeoMeta({
       <NuxtPage />
     </UMain>
 
-    <USeparator icon="i-simple-icons-nuxtdotjs" />
-
     <UFooter>
       <template #left>
         <p class="text-sm text-muted">
-          Built with Nuxt UI • © {{ new Date().getFullYear() }}
+          cartwatch © {{ new Date().getFullYear() }}
         </p>
-      </template>
-
-      <template #right>
-        <UButton
-          to="https://github.com/nuxt-ui-templates/starter"
-          target="_blank"
-          icon="i-simple-icons-github"
-          aria-label="GitHub"
-          color="neutral"
-          variant="ghost"
-        />
       </template>
     </UFooter>
   </UApp>

--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -21,7 +21,8 @@ useSeoMeta({
 
         <UNavigationMenu
           :items="[
-            { label: 'Price History', to: '/prices', icon: 'i-lucide-trending-up' }
+            { label: 'Price History', to: '/prices', icon: 'i-lucide-trending-up' },
+            { label: 'Products', to: '/products', icon: 'i-lucide-table' }
           ]"
           class="ml-4"
         />

--- a/frontend/app/components/DataQualityCard.vue
+++ b/frontend/app/components/DataQualityCard.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+type Column = { key: string; label: string; numeric?: boolean; format?: (v: any) => string }
+
+const props = defineProps<{
+  title: string
+  description: string
+  severity: 'high' | 'medium' | 'low'
+  count: number | null
+  loading: boolean
+  rows: Record<string, any>[]
+  columns: Column[]
+  note?: string
+}>()
+
+const open = ref(false)
+const MAX = 50
+
+const SEV = {
+  high: { badge: 'error' as const, icon: 'i-lucide-circle-alert', iconClass: 'text-error' },
+  medium: { badge: 'warning' as const, icon: 'i-lucide-triangle-alert', iconClass: 'text-warning' },
+  low: { badge: 'neutral' as const, icon: 'i-lucide-info', iconClass: 'text-muted' }
+}
+
+const clean = computed(() => props.count === 0)
+const visibleRows = computed(() => props.rows.slice(0, MAX))
+</script>
+
+<template>
+  <div class="border border-default rounded-xl overflow-hidden">
+    <button
+      class="w-full flex items-center gap-3 px-4 py-3 text-left transition-colors"
+      :class="clean ? 'cursor-default' : 'hover:bg-elevated/50'"
+      :disabled="clean || loading"
+      @click="open = !open"
+    >
+      <UIcon
+        :name="clean ? 'i-lucide-circle-check' : SEV[severity].icon"
+        class="text-lg shrink-0"
+        :class="clean ? 'text-success' : SEV[severity].iconClass"
+      />
+      <div class="min-w-0">
+        <div class="font-semibold">
+          {{ title }}
+        </div>
+        <p class="text-sm text-muted truncate">
+          {{ description }}
+        </p>
+      </div>
+      <div class="ml-auto flex items-center gap-3 shrink-0">
+        <UIcon v-if="loading" name="i-lucide-loader-circle" class="animate-spin text-muted" />
+        <template v-else>
+          <UBadge v-if="clean" color="success" variant="subtle" icon="i-lucide-check">
+            Clean
+          </UBadge>
+          <UBadge v-else-if="count === null" color="neutral" variant="subtle">
+            —
+          </UBadge>
+          <UBadge v-else :color="SEV[severity].badge" variant="subtle">
+            {{ new Intl.NumberFormat().format(count) }}
+          </UBadge>
+        </template>
+        <UIcon
+          v-if="!clean && !loading"
+          :name="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
+          class="text-muted"
+        />
+      </div>
+    </button>
+
+    <div v-if="open && !clean" class="border-t border-default">
+      <div v-if="!rows.length" class="px-4 py-6 text-center text-muted text-sm">
+        No detail rows available.
+      </div>
+      <div v-else class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-default bg-elevated/30">
+              <th
+                v-for="c in columns"
+                :key="c.key"
+                class="px-4 py-2 font-medium text-muted whitespace-nowrap"
+                :class="c.numeric ? 'text-right' : 'text-left'"
+              >
+                {{ c.label }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="(row, i) in visibleRows"
+              :key="i"
+              class="border-b border-default last:border-0"
+            >
+              <td
+                v-for="c in columns"
+                :key="c.key"
+                class="px-4 py-1.5 whitespace-nowrap"
+                :class="c.numeric ? 'text-right tabular-nums' : 'text-left'"
+              >
+                {{ c.format ? c.format(row[c.key]) : (row[c.key] ?? '—') }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <p
+          v-if="rows.length > MAX"
+          class="px-4 py-2 text-xs text-muted border-t border-default"
+        >
+          Showing {{ MAX }} of {{ new Intl.NumberFormat().format(rows.length) }}.
+        </p>
+        <p
+          v-else-if="note"
+          class="px-4 py-2 text-xs text-muted border-t border-default"
+        >
+          {{ note }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/app/components/ProductChart.vue
+++ b/frontend/app/components/ProductChart.vue
@@ -289,6 +289,14 @@ const chartOptions = computed(() => ({
   <UCard>
     <template #header>
       <div class="flex items-center gap-2 flex-wrap">
+        <div
+          class="drag-handle cursor-grab active:cursor-grabbing text-muted hover:text-default shrink-0 flex items-center"
+          draggable="true"
+          aria-label="Drag to reorder"
+          title="Drag to reorder"
+        >
+          <UIcon name="i-lucide-grip-vertical" />
+        </div>
         <div class="flex items-center gap-2 min-w-0">
           <UIcon name="i-lucide-package" class="text-muted shrink-0" />
           <h3 class="font-semibold truncate">

--- a/frontend/app/components/ProductChart.vue
+++ b/frontend/app/components/ProductChart.vue
@@ -11,11 +11,12 @@ import {
   TimeScale
 } from 'chart.js'
 import 'chartjs-adapter-date-fns'
+import zoomPlugin from 'chartjs-plugin-zoom'
 import { Line } from 'vue-chartjs'
 
 ChartJS.register(
   CategoryScale, LinearScale, PointElement, LineElement,
-  Title, Tooltip, Legend, TimeScale
+  Title, Tooltip, Legend, TimeScale, zoomPlugin
 )
 
 const props = defineProps<{
@@ -129,6 +130,20 @@ const chartData = computed(() => {
   }
 })
 
+// ── zoom / pan ──────────────────────────────────────────────────────────
+const chartRef = ref<{ chart?: import('chart.js').Chart }>()
+const zoomMode = ref<'xy' | 'x' | 'y'>('xy')
+
+function zoomIn() {
+  chartRef.value?.chart?.zoom(1.2)
+}
+function zoomOut() {
+  chartRef.value?.chart?.zoom(0.8)
+}
+function resetZoom() {
+  chartRef.value?.chart?.resetZoom()
+}
+
 const chartOptions = computed(() => ({
   responsive: true,
   maintainAspectRatio: false,
@@ -160,6 +175,25 @@ const chartOptions = computed(() => ({
           const qty = `Qty: ${m.quantity}${m.item_unit ? ` ${m.item_unit}` : ''}`
           return [qty, date]
         }
+      }
+    },
+    zoom: {
+      // Hold Shift and drag to pan; plain drag draws a zoom box.
+      pan: { enabled: true, mode: zoomMode.value, modifierKey: 'shift' as const },
+      zoom: {
+        wheel: { enabled: true },
+        pinch: { enabled: false },
+        drag: {
+          enabled: true,
+          backgroundColor: 'rgba(34,197,94,0.15)',
+          borderColor: 'rgba(34,197,94,0.7)',
+          borderWidth: 1
+        },
+        mode: zoomMode.value
+      },
+      limits: {
+        x: { min: 'original' as const, max: 'original' as const },
+        y: { min: 'original' as const, max: 'original' as const }
       }
     }
   }
@@ -197,15 +231,63 @@ const chartOptions = computed(() => ({
           </UBadge>
         </div>
 
-        <UButton
-          size="xs"
-          color="error"
-          variant="ghost"
-          icon="i-lucide-x"
-          aria-label="Remove chart"
-          class="ml-auto"
-          @click="$emit('remove')"
-        />
+        <div class="flex items-center gap-1 ml-auto">
+          <UButtonGroup size="xs">
+            <UButton
+              :variant="zoomMode === 'xy' ? 'solid' : 'outline'"
+              color="neutral"
+              @click="zoomMode = 'xy'"
+            >
+              XY
+            </UButton>
+            <UButton
+              :variant="zoomMode === 'x' ? 'solid' : 'outline'"
+              color="neutral"
+              @click="zoomMode = 'x'"
+            >
+              X
+            </UButton>
+            <UButton
+              :variant="zoomMode === 'y' ? 'solid' : 'outline'"
+              color="neutral"
+              @click="zoomMode = 'y'"
+            >
+              Y
+            </UButton>
+          </UButtonGroup>
+          <UButton
+            size="xs"
+            color="neutral"
+            variant="ghost"
+            icon="i-lucide-zoom-in"
+            aria-label="Zoom in"
+            @click="zoomIn"
+          />
+          <UButton
+            size="xs"
+            color="neutral"
+            variant="ghost"
+            icon="i-lucide-zoom-out"
+            aria-label="Zoom out"
+            @click="zoomOut"
+          />
+          <UButton
+            size="xs"
+            color="neutral"
+            variant="ghost"
+            icon="i-lucide-rotate-ccw"
+            aria-label="Reset zoom"
+            @click="resetZoom"
+          />
+          <UButton
+            size="xs"
+            color="error"
+            variant="ghost"
+            icon="i-lucide-x"
+            aria-label="Remove chart"
+            @click="$emit('remove')"
+          />
+        </div>
       </div>
     </template>
 
@@ -219,8 +301,13 @@ const chartOptions = computed(() => ({
       <UIcon name="i-lucide-inbox" class="text-3xl mb-2" />
       <p>No price history for <strong>{{ product.name }}</strong>.</p>
     </div>
-    <div v-else class="h-72">
-      <Line :data="chartData" :options="chartOptions" />
+    <div v-else>
+      <div class="h-72">
+        <Line ref="chartRef" :data="chartData" :options="chartOptions" />
+      </div>
+      <p class="text-xs text-muted mt-2 text-center">
+        Scroll to zoom · drag to box-zoom · shift-drag to pan · X/Y locks an axis
+      </p>
     </div>
   </UCard>
 </template>

--- a/frontend/app/components/ProductChart.vue
+++ b/frontend/app/components/ProductChart.vue
@@ -144,6 +144,54 @@ function resetZoom() {
   chartRef.value?.chart?.resetZoom()
 }
 
+// Direction-aware box zoom: in XY mode the plugin zooms both axes to the drag
+// box; afterwards we undo the axis that barely moved, so a flat drag zooms only
+// X and a tall drag only Y. An explicit X/Y toggle wins. (The plugin caches its
+// own mode, so we can't influence it live — hence the after-the-fact restore.)
+let dragProbe: { x: number; y: number } | null = null
+let dragVec = { dx: 0, dy: 0 }
+let preX: { min: number; max: number } | null = null
+let preY: { min: number; max: number } | null = null
+function dragMode(): 'x' | 'y' | 'xy' {
+  if (zoomMode.value !== 'xy') return zoomMode.value
+  const { dx, dy } = dragVec
+  const MIN = 12 // px — below this the drag is too small to have a direction
+  const DOMINANCE = 2.5 // one axis must be this many times longer to lock to it
+  if (dx < MIN && dy < MIN) return 'xy'
+  if (dx >= dy * DOMINANCE) return 'x'
+  if (dy >= dx * DOMINANCE) return 'y'
+  return 'xy'
+}
+function onDragProbeDown(e: MouseEvent) {
+  if (e.shiftKey) return // shift-drag pans, not zooms
+  dragProbe = { x: e.clientX, y: e.clientY }
+  dragVec = { dx: 0, dy: 0 }
+  const chart = chartRef.value?.chart
+  if (chart) {
+    preX = { min: chart.scales.x.min, max: chart.scales.x.max }
+    preY = { min: chart.scales.y.min, max: chart.scales.y.max }
+  }
+}
+function onDragProbeMove(e: MouseEvent) {
+  if (!dragProbe) return
+  dragVec = { dx: Math.abs(e.clientX - dragProbe.x), dy: Math.abs(e.clientY - dragProbe.y) }
+}
+function onDragProbeUp() {
+  if (!dragProbe) return
+  dragProbe = null
+  const m = dragMode()
+  const chart = chartRef.value?.chart
+  if (m === 'xy' || !chart || !preX || !preY) return
+  const px = preX
+  const py = preY
+  // The drag zoom lands first; on the next frame reset the near-flat axis.
+  requestAnimationFrame(() => {
+    const z = chart as unknown as { zoomScale: (id: string, range: { min: number; max: number }, t: string) => void }
+    if (m === 'x') z.zoomScale('y', { min: py.min, max: py.max }, 'none')
+    else z.zoomScale('x', { min: px.min, max: px.max }, 'none')
+  })
+}
+
 // Grab cursor: hint pan-ability on Shift-hover, show a closed fist while panning.
 let shiftHeld = false
 let panning = false
@@ -339,11 +387,19 @@ const chartOptions = computed(() => ({
       <p>No price history for <strong>{{ product.name }}</strong>.</p>
     </div>
     <div v-else>
-      <div class="h-72" @mouseenter="onChartEnter" @mouseleave="onChartLeave">
+      <div
+        class="h-72"
+        @mouseenter="onChartEnter"
+        @mouseleave="onChartLeave"
+        @dblclick="resetZoom"
+        @mousedown="onDragProbeDown"
+        @mousemove="onDragProbeMove"
+        @mouseup="onDragProbeUp"
+      >
         <Line ref="chartRef" :data="chartData" :options="chartOptions" />
       </div>
       <p class="text-xs text-muted mt-2 text-center">
-        Scroll to zoom · drag to box-zoom · shift-drag to pan · X/Y locks an axis
+        Scroll to zoom · drag to box-zoom · double-click to reset · shift-drag to pan
       </p>
     </div>
   </UCard>

--- a/frontend/app/components/ProductChart.vue
+++ b/frontend/app/components/ProductChart.vue
@@ -113,21 +113,61 @@ const yAxisLabel = computed(() =>
   `Price (${currencySymbol.value}${displayUnit.value ? ` / ${displayUnit.value}` : ''})`
 )
 
+function median(nums: number[]) {
+  const s = [...nums].sort((a, b) => a - b)
+  const mid = Math.floor(s.length / 2)
+  return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2
+}
+function startOfDay(ts: number) {
+  const d = new Date(ts)
+  d.setHours(0, 0, 0, 0)
+  return d.getTime()
+}
+
+// Two datasets per chain: the raw observations as dots (no line), plus a line
+// that connects the daily median — so multiple purchases on one day no longer
+// make the line zig-zag, while every real data point stays visible.
 const chartData = computed(() => {
   const chains = [...new Set(history.value.map(p => p.store_chain))]
-  return {
-    datasets: chains.map(chain => ({
+  const datasets: any[] = []
+  for (const chain of chains) {
+    const color = CHAIN_COLORS[chain] ?? '#94a3b8'
+    const points = history.value.filter(p => p.store_chain === chain)
+
+    // raw dots (kept so nothing is hidden)
+    datasets.push({
+      label: `${chain} (raw)`,
+      data: points.map(p => ({ x: new Date(p.date).getTime(), y: p.unit_price, meta: p })),
+      showLine: false,
+      pointRadius: 3,
+      pointHoverRadius: 6,
+      pointBackgroundColor: color,
+      borderColor: color
+    })
+
+    // daily-median line
+    const byDay = new Map<number, number[]>()
+    for (const p of points) {
+      const key = startOfDay(new Date(p.date).getTime())
+      const arr = byDay.get(key) ?? []
+      arr.push(p.unit_price)
+      byDay.set(key, arr)
+    }
+    const line = [...byDay.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([x, prices]) => ({ x, y: median(prices) }))
+    datasets.push({
       label: chain,
-      data: history.value
-        .filter(p => p.store_chain === chain)
-        .map(p => ({ x: new Date(p.date).getTime(), y: p.unit_price, meta: p })),
-      borderColor: CHAIN_COLORS[chain] ?? '#94a3b8',
-      backgroundColor: (CHAIN_COLORS[chain] ?? '#94a3b8') + '33',
+      data: line,
+      borderColor: color,
+      backgroundColor: color + '33',
       tension: 0.3,
-      pointRadius: 4,
-      pointHoverRadius: 6
-    }))
+      borderWidth: 2,
+      pointRadius: 0,
+      pointHoverRadius: 0
+    })
   }
+  return { datasets }
 })
 
 // ── zoom / pan ──────────────────────────────────────────────────────────
@@ -144,52 +184,94 @@ function resetZoom() {
   chartRef.value?.chart?.resetZoom()
 }
 
-// Direction-aware box zoom: in XY mode the plugin zooms both axes to the drag
-// box; afterwards we undo the axis that barely moved, so a flat drag zooms only
-// X and a tall drag only Y. An explicit X/Y toggle wins. (The plugin caches its
-// own mode, so we can't influence it live — hence the after-the-fact restore.)
-let dragProbe: { x: number; y: number } | null = null
-let dragVec = { dx: 0, dy: 0 }
-let preX: { min: number; max: number } | null = null
-let preY: { min: number; max: number } | null = null
-function dragMode(): 'x' | 'y' | 'xy' {
+// Custom box zoom with an axis-matching preview: a mostly-horizontal drag locks
+// to X (full-height band), a mostly-vertical drag to Y (full-width band), and a
+// square-ish drag zooms both. An explicit X/Y toggle overrides the auto choice.
+// Done by hand (the plugin's own drag is disabled) so the preview band always
+// matches what actually gets zoomed.
+type Pt = { x: number; y: number }
+type BoxStyle = { left: string; top: string; width: string; height: string; background: string; border: string }
+const boxStyle = ref<BoxStyle | null>(null)
+let boxStart: Pt | null = null
+const MIN_DRAG = 8 // px — below this it's a click, not a zoom
+const DOMINANCE = 2 // one axis must be this many times longer to lock to it
+
+function clamp(v: number, lo: number, hi: number) {
+  return Math.max(lo, Math.min(hi, v))
+}
+function pointerPos(e: MouseEvent): Pt | null {
+  const chart = chartRef.value?.chart
+  if (!chart) return null
+  const rect = chart.canvas.getBoundingClientRect()
+  const ca = chart.chartArea
+  return {
+    x: clamp(e.clientX - rect.left, ca.left, ca.right),
+    y: clamp(e.clientY - rect.top, ca.top, ca.bottom)
+  }
+}
+function boxMode(dx: number, dy: number): 'x' | 'y' | 'xy' {
   if (zoomMode.value !== 'xy') return zoomMode.value
-  const { dx, dy } = dragVec
-  const MIN = 12 // px — below this the drag is too small to have a direction
-  const DOMINANCE = 2.5 // one axis must be this many times longer to lock to it
-  if (dx < MIN && dy < MIN) return 'xy'
+  if (dx < MIN_DRAG && dy < MIN_DRAG) return 'xy'
   if (dx >= dy * DOMINANCE) return 'x'
   if (dy >= dx * DOMINANCE) return 'y'
   return 'xy'
 }
-function onDragProbeDown(e: MouseEvent) {
-  if (e.shiftKey) return // shift-drag pans, not zooms
-  dragProbe = { x: e.clientX, y: e.clientY }
-  dragVec = { dx: 0, dy: 0 }
+function onBoxDown(e: MouseEvent) {
+  if (e.shiftKey) return // shift-drag pans
+  boxStart = pointerPos(e)
+  boxStyle.value = null
+}
+function onBoxMove(e: MouseEvent) {
   const chart = chartRef.value?.chart
-  if (chart) {
-    preX = { min: chart.scales.x.min, max: chart.scales.x.max }
-    preY = { min: chart.scales.y.min, max: chart.scales.y.max }
+  const p = pointerPos(e)
+  if (!boxStart || !chart || !p) return
+  const ca = chart.chartArea
+  const dx = Math.abs(p.x - boxStart.x)
+  const dy = Math.abs(p.y - boxStart.y)
+  const mode = boxMode(dx, dy)
+  let left: number, top: number, width: number, height: number
+  if (mode === 'x') {
+    left = Math.min(boxStart.x, p.x); width = dx; top = ca.top; height = ca.bottom - ca.top
+  } else if (mode === 'y') {
+    top = Math.min(boxStart.y, p.y); height = dy; left = ca.left; width = ca.right - ca.left
+  } else {
+    left = Math.min(boxStart.x, p.x); top = Math.min(boxStart.y, p.y); width = dx; height = dy
+  }
+  boxStyle.value = {
+    left: `${left}px`,
+    top: `${top}px`,
+    width: `${width}px`,
+    height: `${height}px`,
+    background: 'rgba(34,197,94,0.15)',
+    border: '1px solid rgba(34,197,94,0.7)'
   }
 }
-function onDragProbeMove(e: MouseEvent) {
-  if (!dragProbe) return
-  dragVec = { dx: Math.abs(e.clientX - dragProbe.x), dy: Math.abs(e.clientY - dragProbe.y) }
-}
-function onDragProbeUp() {
-  if (!dragProbe) return
-  dragProbe = null
-  const m = dragMode()
+function onBoxUp(e: MouseEvent) {
+  const start = boxStart
+  boxStart = null
+  boxStyle.value = null
   const chart = chartRef.value?.chart
-  if (m === 'xy' || !chart || !preX || !preY) return
-  const px = preX
-  const py = preY
-  // The drag zoom lands first; on the next frame reset the near-flat axis.
-  requestAnimationFrame(() => {
-    const z = chart as unknown as { zoomScale: (id: string, range: { min: number; max: number }, t: string) => void }
-    if (m === 'x') z.zoomScale('y', { min: py.min, max: py.max }, 'none')
-    else z.zoomScale('x', { min: px.min, max: px.max }, 'none')
-  })
+  const p = pointerPos(e)
+  if (!start || !chart || !p) return
+  const dx = Math.abs(p.x - start.x)
+  const dy = Math.abs(p.y - start.y)
+  if (dx < MIN_DRAG && dy < MIN_DRAG) return // a click, not a zoom
+  const mode = boxMode(dx, dy)
+  const z = chart as unknown as { zoomScale: (id: string, range: { min: number; max: number }, t: string) => void }
+  if (mode === 'x' || mode === 'xy') {
+    const a = chart.scales.x.getValueForPixel(Math.min(start.x, p.x))!
+    const b = chart.scales.x.getValueForPixel(Math.max(start.x, p.x))!
+    z.zoomScale('x', { min: Math.min(a, b), max: Math.max(a, b) }, 'none')
+  }
+  if (mode === 'y' || mode === 'xy') {
+    const a = chart.scales.y.getValueForPixel(Math.min(start.y, p.y))!
+    const b = chart.scales.y.getValueForPixel(Math.max(start.y, p.y))!
+    z.zoomScale('y', { min: Math.min(a, b), max: Math.max(a, b) }, 'none')
+  }
+}
+function cancelBox() {
+  boxStart = null
+  boxStyle.value = null
 }
 
 // Grab cursor: hint pan-ability on Shift-hover, show a closed fist while panning.
@@ -199,7 +281,13 @@ let hovering = false
 function applyCursor() {
   const canvas = chartRef.value?.chart?.canvas
   if (!canvas) return
-  canvas.style.cursor = panning ? 'grabbing' : (hovering && shiftHeld ? 'grab' : '')
+  canvas.style.cursor = panning
+    ? 'grabbing'
+    : hovering && shiftHeld
+      ? 'grab'
+      : hovering
+        ? 'crosshair'
+        : ''
 }
 function onShiftKey(e: KeyboardEvent) {
   if (e.key !== 'Shift') return
@@ -212,6 +300,7 @@ function onChartEnter() {
 }
 function onChartLeave() {
   hovering = false
+  cancelBox()
   applyCursor()
 }
 onMounted(() => {
@@ -239,17 +328,22 @@ const chartOptions = computed(() => ({
     }
   },
   plugins: {
-    legend: { position: 'bottom' as const },
+    legend: {
+      position: 'bottom' as const,
+      labels: { filter: (item: any) => !item.text.endsWith('(raw)') }
+    },
     tooltip: {
       callbacks: {
         title: (items: any[]) => items[0]?.raw?.meta?.raw_name ?? '',
         label: (ctx: any) => {
-          const m = ctx.raw.meta as PricePoint
+          const m = ctx.raw?.meta as PricePoint | undefined
+          if (!m) return ''
           const unit = displayUnit.value ?? m.item_unit
           return `${ctx.dataset.label}: ${currencySymbol.value}${ctx.parsed.y.toFixed(2)}${unit ? ` / ${unit}` : ''}`
         },
         afterLabel: (ctx: any) => {
-          const m = ctx.raw.meta as PricePoint
+          const m = ctx.raw?.meta as PricePoint | undefined
+          if (!m) return []
           const date = new Date(m.date).toLocaleDateString()
           const qty = `Qty: ${m.quantity}${m.item_unit ? ` ${m.item_unit}` : ''}`
           return [qty, date]
@@ -268,12 +362,9 @@ const chartOptions = computed(() => ({
       zoom: {
         wheel: { enabled: true },
         pinch: { enabled: false },
-        drag: {
-          enabled: true,
-          backgroundColor: 'rgba(34,197,94,0.15)',
-          borderColor: 'rgba(34,197,94,0.7)',
-          borderWidth: 1
-        },
+        // Box zoom is handled manually (onBoxDown/Move/Up) so the preview band
+        // matches the locked axis; the plugin still owns wheel + pan.
+        drag: { enabled: false },
         mode: zoomMode.value
       },
       limits: {
@@ -396,18 +487,23 @@ const chartOptions = computed(() => ({
     </div>
     <div v-else>
       <div
-        class="h-72"
+        class="relative h-72"
         @mouseenter="onChartEnter"
         @mouseleave="onChartLeave"
         @dblclick="resetZoom"
-        @mousedown="onDragProbeDown"
-        @mousemove="onDragProbeMove"
-        @mouseup="onDragProbeUp"
+        @mousedown="onBoxDown"
+        @mousemove="onBoxMove"
+        @mouseup="onBoxUp"
       >
         <Line ref="chartRef" :data="chartData" :options="chartOptions" />
+        <div
+          v-if="boxStyle"
+          class="absolute pointer-events-none rounded-sm"
+          :style="boxStyle"
+        />
       </div>
       <p class="text-xs text-muted mt-2 text-center">
-        Scroll to zoom · drag to box-zoom · double-click to reset · shift-drag to pan
+        Scroll to zoom · drag a box (thin → one axis) · double-click to reset · shift-drag to pan
       </p>
     </div>
   </UCard>

--- a/frontend/app/components/ProductChart.vue
+++ b/frontend/app/components/ProductChart.vue
@@ -144,6 +144,37 @@ function resetZoom() {
   chartRef.value?.chart?.resetZoom()
 }
 
+// Grab cursor: hint pan-ability on Shift-hover, show a closed fist while panning.
+let shiftHeld = false
+let panning = false
+let hovering = false
+function applyCursor() {
+  const canvas = chartRef.value?.chart?.canvas
+  if (!canvas) return
+  canvas.style.cursor = panning ? 'grabbing' : (hovering && shiftHeld ? 'grab' : '')
+}
+function onShiftKey(e: KeyboardEvent) {
+  if (e.key !== 'Shift') return
+  shiftHeld = e.type === 'keydown'
+  applyCursor()
+}
+function onChartEnter() {
+  hovering = true
+  applyCursor()
+}
+function onChartLeave() {
+  hovering = false
+  applyCursor()
+}
+onMounted(() => {
+  window.addEventListener('keydown', onShiftKey)
+  window.addEventListener('keyup', onShiftKey)
+})
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onShiftKey)
+  window.removeEventListener('keyup', onShiftKey)
+})
+
 const chartOptions = computed(() => ({
   responsive: true,
   maintainAspectRatio: false,
@@ -179,7 +210,13 @@ const chartOptions = computed(() => ({
     },
     zoom: {
       // Hold Shift and drag to pan; plain drag draws a zoom box.
-      pan: { enabled: true, mode: zoomMode.value, modifierKey: 'shift' as const },
+      pan: {
+        enabled: true,
+        mode: zoomMode.value,
+        modifierKey: 'shift' as const,
+        onPanStart: () => { panning = true; applyCursor() },
+        onPanComplete: () => { panning = false; applyCursor() }
+      },
       zoom: {
         wheel: { enabled: true },
         pinch: { enabled: false },
@@ -302,7 +339,7 @@ const chartOptions = computed(() => ({
       <p>No price history for <strong>{{ product.name }}</strong>.</p>
     </div>
     <div v-else>
-      <div class="h-72">
+      <div class="h-72" @mouseenter="onChartEnter" @mouseleave="onChartLeave">
         <Line ref="chartRef" :data="chartData" :options="chartOptions" />
       </div>
       <p class="text-xs text-muted mt-2 text-center">

--- a/frontend/app/components/ProductChart.vue
+++ b/frontend/app/components/ProductChart.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  TimeScale
+} from 'chart.js'
+import 'chartjs-adapter-date-fns'
+import { Line } from 'vue-chartjs'
+
+ChartJS.register(
+  CategoryScale, LinearScale, PointElement, LineElement,
+  Title, Tooltip, Legend, TimeScale
+)
+
+const props = defineProps<{
+  product: { id: string; name: string; short_name: string; unit: string | null }
+}>()
+defineEmits<{ remove: [] }>()
+
+const supabase = useSupabaseClient()
+
+type PricePoint = {
+  date: string
+  unit_price: number
+  store_chain: string
+  raw_name: string
+  quantity: number
+  item_unit: string
+  currency: string
+}
+const history = ref<PricePoint[]>([])
+const loading = ref(true)
+
+const CHAIN_COLORS: Record<string, string> = {
+  REWE: '#e2001a',
+  Lidl: '#0050aa',
+  'Aldi Süd': '#00519e',
+  'Aldi Nord': '#003087',
+  Edeka: '#f5a800',
+  Penny: '#c8102e',
+  Netto: '#ffd100',
+  Kaufland: '#e2001a',
+  dm: '#d40511',
+  Rossmann: '#e2001a',
+  Amazon: '#ff9900',
+  Other: '#94a3b8'
+}
+
+const CURRENCY_SYMBOLS: Record<string, string> = { EUR: '€', USD: '$', GBP: '£' }
+
+async function loadHistory() {
+  loading.value = true
+  history.value = []
+
+  const { data } = await supabase
+    .from('receipt_items')
+    .select(`
+      raw_name,
+      quantity,
+      unit_price,
+      units ( symbol ),
+      receipts!inner (
+        purchased_at,
+        currency,
+        stores!inner (
+          store_chains!inner ( name )
+        )
+      )
+    `)
+    .eq('canonical_product_id', props.product.id)
+    .order('receipts(purchased_at)', { ascending: true })
+
+  if (data) {
+    history.value = data.map((row: any) => ({
+      date: row.receipts.purchased_at,
+      unit_price: row.unit_price,
+      store_chain: row.receipts.stores.store_chains.name,
+      raw_name: row.raw_name,
+      quantity: row.quantity,
+      item_unit: row.units?.symbol ?? '',
+      currency: row.receipts.currency
+    }))
+  }
+  loading.value = false
+}
+onMounted(loadHistory)
+
+const currencySymbol = computed(() => {
+  const c = history.value[0]?.currency ?? 'EUR'
+  return CURRENCY_SYMBOLS[c] ?? `${c} `
+})
+
+const distinctUnits = computed(() =>
+  [...new Set(history.value.map(p => p.item_unit).filter(Boolean))]
+)
+
+const displayUnit = computed(() =>
+  props.product.unit ?? (distinctUnits.value.length === 1 ? distinctUnits.value[0]! : null)
+)
+
+const unitsMixed = computed(() =>
+  !props.product.unit && distinctUnits.value.length > 1
+)
+
+const yAxisLabel = computed(() =>
+  `Price (${currencySymbol.value}${displayUnit.value ? ` / ${displayUnit.value}` : ''})`
+)
+
+const chartData = computed(() => {
+  const chains = [...new Set(history.value.map(p => p.store_chain))]
+  return {
+    datasets: chains.map(chain => ({
+      label: chain,
+      data: history.value
+        .filter(p => p.store_chain === chain)
+        .map(p => ({ x: new Date(p.date).getTime(), y: p.unit_price, meta: p })),
+      borderColor: CHAIN_COLORS[chain] ?? '#94a3b8',
+      backgroundColor: (CHAIN_COLORS[chain] ?? '#94a3b8') + '33',
+      tension: 0.3,
+      pointRadius: 4,
+      pointHoverRadius: 6
+    }))
+  }
+})
+
+const chartOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  interaction: { mode: 'nearest' as const, intersect: true },
+  scales: {
+    x: {
+      type: 'time' as const,
+      time: { unit: 'month' as const },
+      title: { display: true, text: 'Date' }
+    },
+    y: {
+      title: { display: true, text: yAxisLabel.value },
+      ticks: { callback: (v: any) => `${currencySymbol.value}${Number(v).toFixed(2)}` }
+    }
+  },
+  plugins: {
+    legend: { position: 'bottom' as const },
+    tooltip: {
+      callbacks: {
+        title: (items: any[]) => items[0]?.raw?.meta?.raw_name ?? '',
+        label: (ctx: any) => {
+          const m = ctx.raw.meta as PricePoint
+          const unit = displayUnit.value ?? m.item_unit
+          return `${ctx.dataset.label}: ${currencySymbol.value}${ctx.parsed.y.toFixed(2)}${unit ? ` / ${unit}` : ''}`
+        },
+        afterLabel: (ctx: any) => {
+          const m = ctx.raw.meta as PricePoint
+          const date = new Date(m.date).toLocaleDateString()
+          const qty = `Qty: ${m.quantity}${m.item_unit ? ` ${m.item_unit}` : ''}`
+          return [qty, date]
+        }
+      }
+    }
+  }
+}))
+</script>
+
+<template>
+  <UCard>
+    <template #header>
+      <div class="flex items-center gap-2 flex-wrap">
+        <div class="flex items-center gap-2 min-w-0">
+          <UIcon name="i-lucide-package" class="text-muted shrink-0" />
+          <h3 class="font-semibold truncate">
+            {{ product.name }}
+          </h3>
+          <UBadge v-if="!loading && history.length" variant="subtle" size="sm">
+            {{ history.length }} pts
+          </UBadge>
+          <UBadge
+            v-if="displayUnit && !unitsMixed"
+            color="neutral"
+            variant="outline"
+            size="sm"
+          >
+            {{ currencySymbol }} / {{ displayUnit }}
+          </UBadge>
+          <UBadge
+            v-if="unitsMixed"
+            color="warning"
+            variant="subtle"
+            size="sm"
+            icon="i-lucide-triangle-alert"
+          >
+            Mixed: {{ distinctUnits.join(', ') }}
+          </UBadge>
+        </div>
+
+        <UButton
+          size="xs"
+          color="error"
+          variant="ghost"
+          icon="i-lucide-x"
+          aria-label="Remove chart"
+          class="ml-auto"
+          @click="$emit('remove')"
+        />
+      </div>
+    </template>
+
+    <div v-if="loading" class="flex justify-center items-center h-72">
+      <UIcon name="i-lucide-loader-circle" class="animate-spin text-2xl text-muted" />
+    </div>
+    <div
+      v-else-if="!history.length"
+      class="flex flex-col items-center justify-center h-72 text-muted"
+    >
+      <UIcon name="i-lucide-inbox" class="text-3xl mb-2" />
+      <p>No price history for <strong>{{ product.name }}</strong>.</p>
+    </div>
+    <div v-else class="h-72">
+      <Line :data="chartData" :options="chartOptions" />
+    </div>
+  </UCard>
+</template>

--- a/frontend/app/components/ProductChart.vue
+++ b/frontend/app/components/ProductChart.vue
@@ -21,6 +21,7 @@ ChartJS.register(
 
 const props = defineProps<{
   product: { id: string; name: string; short_name: string; unit: string | null }
+  jitter?: boolean
 }>()
 defineEmits<{ remove: [] }>()
 
@@ -118,15 +119,14 @@ function median(nums: number[]) {
   const mid = Math.floor(s.length / 2)
   return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2
 }
-function startOfDay(ts: number) {
+function startOfMonth(ts: number) {
   const d = new Date(ts)
-  d.setHours(0, 0, 0, 0)
-  return d.getTime()
+  return new Date(d.getFullYear(), d.getMonth(), 1).getTime()
 }
+const JITTER_MS = 4 * 24 * 60 * 60 * 1000 // spread same-day dots by up to ±4 days
 
-// Two datasets per chain: the raw observations as dots (no line), plus a line
-// that connects the daily median — so multiple purchases on one day no longer
-// make the line zig-zag, while every real data point stays visible.
+// Two datasets per chain: the raw observations as dots, plus a solid line
+// through the monthly median. Every raw observation stays visible.
 const chartData = computed(() => {
   const chains = [...new Set(history.value.map(p => p.store_chain))]
   const datasets: any[] = []
@@ -134,10 +134,14 @@ const chartData = computed(() => {
     const color = CHAIN_COLORS[chain] ?? '#94a3b8'
     const points = history.value.filter(p => p.store_chain === chain)
 
-    // raw dots (kept so nothing is hidden)
+    // raw dots — optionally jittered on the date axis to reveal same-day overlaps
     datasets.push({
       label: `${chain} (raw)`,
-      data: points.map(p => ({ x: new Date(p.date).getTime(), y: p.unit_price, meta: p })),
+      data: points.map((p) => {
+        const base = new Date(p.date).getTime()
+        const x = props.jitter ? base + (Math.random() * 2 - 1) * JITTER_MS : base
+        return { x, y: p.unit_price, meta: p }
+      }),
       showLine: false,
       pointRadius: 3,
       pointHoverRadius: 6,
@@ -145,24 +149,24 @@ const chartData = computed(() => {
       borderColor: color
     })
 
-    // daily-median line
-    const byDay = new Map<number, number[]>()
+    // monthly-median line — dashed + diamond markers = "this is calculated"
+    const byMonth = new Map<number, number[]>()
     for (const p of points) {
-      const key = startOfDay(new Date(p.date).getTime())
-      const arr = byDay.get(key) ?? []
+      const key = startOfMonth(new Date(p.date).getTime())
+      const arr = byMonth.get(key) ?? []
       arr.push(p.unit_price)
-      byDay.set(key, arr)
+      byMonth.set(key, arr)
     }
-    const line = [...byDay.entries()]
+    const line = [...byMonth.entries()]
       .sort((a, b) => a[0] - b[0])
-      .map(([x, prices]) => ({ x, y: median(prices) }))
+      .map(([x, prices]) => ({ x, y: median(prices), agg: true }))
     datasets.push({
       label: chain,
       data: line,
       borderColor: color,
       backgroundColor: color + '33',
-      tension: 0.3,
       borderWidth: 2,
+      tension: 0.3,
       pointRadius: 0,
       pointHoverRadius: 0
     })
@@ -172,7 +176,6 @@ const chartData = computed(() => {
 
 // ── zoom / pan ──────────────────────────────────────────────────────────
 const chartRef = ref<{ chart?: import('chart.js').Chart }>()
-const zoomMode = ref<'xy' | 'x' | 'y'>('xy')
 
 function zoomIn() {
   chartRef.value?.chart?.zoom(1.2)
@@ -210,7 +213,7 @@ function pointerPos(e: MouseEvent): Pt | null {
   }
 }
 function boxMode(dx: number, dy: number): 'x' | 'y' | 'xy' {
-  if (zoomMode.value !== 'xy') return zoomMode.value
+  // Axis is chosen by the drag shape: mostly-horizontal → x, mostly-vertical → y.
   if (dx < MIN_DRAG && dy < MIN_DRAG) return 'xy'
   if (dx >= dy * DOMINANCE) return 'x'
   if (dy >= dx * DOMINANCE) return 'y'
@@ -334,12 +337,19 @@ const chartOptions = computed(() => ({
     },
     tooltip: {
       callbacks: {
-        title: (items: any[]) => items[0]?.raw?.meta?.raw_name ?? '',
+        title: (items: any[]) => {
+          const raw = items[0]?.raw
+          if (raw?.meta) return raw.meta.raw_name
+          if (raw?.agg) return new Date(raw.x).toLocaleDateString(undefined, { year: 'numeric', month: 'long' })
+          return ''
+        },
         label: (ctx: any) => {
-          const m = ctx.raw?.meta as PricePoint | undefined
-          if (!m) return ''
-          const unit = displayUnit.value ?? m.item_unit
-          return `${ctx.dataset.label}: ${currencySymbol.value}${ctx.parsed.y.toFixed(2)}${unit ? ` / ${unit}` : ''}`
+          const raw = ctx.raw
+          const unit = displayUnit.value ?? raw?.meta?.item_unit
+          const price = `${currencySymbol.value}${ctx.parsed.y.toFixed(2)}${unit ? ` / ${unit}` : ''}`
+          if (raw?.meta) return `${ctx.dataset.label}: ${price}`
+          if (raw?.agg) return `${ctx.dataset.label} · monthly median: ${price}`
+          return ''
         },
         afterLabel: (ctx: any) => {
           const m = ctx.raw?.meta as PricePoint | undefined
@@ -354,7 +364,7 @@ const chartOptions = computed(() => ({
       // Hold Shift and drag to pan; plain drag draws a zoom box.
       pan: {
         enabled: true,
-        mode: zoomMode.value,
+        mode: 'xy' as const,
         modifierKey: 'shift' as const,
         onPanStart: () => { panning = true; applyCursor() },
         onPanComplete: () => { panning = false; applyCursor() }
@@ -365,7 +375,7 @@ const chartOptions = computed(() => ({
         // Box zoom is handled manually (onBoxDown/Move/Up) so the preview band
         // matches the locked axis; the plugin still owns wheel + pan.
         drag: { enabled: false },
-        mode: zoomMode.value
+        mode: 'xy' as const
       },
       limits: {
         x: { min: 'original' as const, max: 'original' as const },
@@ -416,29 +426,6 @@ const chartOptions = computed(() => ({
         </div>
 
         <div class="flex items-center gap-1 ml-auto">
-          <UButtonGroup size="xs">
-            <UButton
-              :variant="zoomMode === 'xy' ? 'solid' : 'outline'"
-              color="neutral"
-              @click="zoomMode = 'xy'"
-            >
-              XY
-            </UButton>
-            <UButton
-              :variant="zoomMode === 'x' ? 'solid' : 'outline'"
-              color="neutral"
-              @click="zoomMode = 'x'"
-            >
-              X
-            </UButton>
-            <UButton
-              :variant="zoomMode === 'y' ? 'solid' : 'outline'"
-              color="neutral"
-              @click="zoomMode = 'y'"
-            >
-              Y
-            </UButton>
-          </UButtonGroup>
           <UButton
             size="xs"
             color="neutral"

--- a/frontend/app/components/ProductStatsTable.vue
+++ b/frontend/app/components/ProductStatsTable.vue
@@ -6,7 +6,6 @@ type Row = {
   unit_symbol: string
   line_item_count: number
   receipt_count: number
-  store_count: number
   retailer_count: number
   median_unit_price: number | null
   min_unit_price: number | null
@@ -20,7 +19,7 @@ const loading = ref(true)
 onMounted(async () => {
   const { data } = await supabase
     .from('mv_product_stats')
-    .select('canonical_product_name, unit_symbol, line_item_count, receipt_count, store_count, retailer_count, median_unit_price, min_unit_price, max_unit_price, total_price_sum')
+    .select('canonical_product_name, unit_symbol, line_item_count, receipt_count, retailer_count, median_unit_price, min_unit_price, max_unit_price, total_price_sum')
   rows.value = (data ?? []) as Row[]
   loading.value = false
 })
@@ -44,7 +43,6 @@ const columns: Col[] = [
   { key: 'unit_symbol', label: 'Unit', numeric: false },
   { key: 'line_item_count', label: 'Obs.', numeric: true, title: 'Line items observed', format: r => fmtInt(r.line_item_count) },
   { key: 'receipt_count', label: 'Receipts', numeric: true, title: 'Distinct receipts', format: r => fmtInt(r.receipt_count) },
-  { key: 'store_count', label: 'Stores', numeric: true, title: 'Distinct stores', format: r => fmtInt(r.store_count) },
   { key: 'retailer_count', label: 'Retailers', numeric: true, title: 'Distinct retailers', format: r => fmtInt(r.retailer_count) },
   { key: 'median_unit_price', label: 'Median', numeric: true, title: 'Median price per unit', format: r => fmtPrice(r.median_unit_price) },
   { key: 'min_unit_price', label: 'Min', numeric: true, title: 'Min price per unit', format: r => fmtPrice(r.min_unit_price) },

--- a/frontend/app/components/ProductStatsTable.vue
+++ b/frontend/app/components/ProductStatsTable.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+const supabase = useSupabaseClient()
+
+type Row = {
+  canonical_product_name: string
+  unit_symbol: string
+  line_item_count: number
+  receipt_count: number
+  store_count: number
+  retailer_count: number
+  median_unit_price: number | null
+  min_unit_price: number | null
+  max_unit_price: number | null
+  total_price_sum: number | null
+}
+
+const rows = ref<Row[]>([])
+const loading = ref(true)
+
+onMounted(async () => {
+  const { data } = await supabase
+    .from('mv_product_stats')
+    .select('canonical_product_name, unit_symbol, line_item_count, receipt_count, store_count, retailer_count, median_unit_price, min_unit_price, max_unit_price, total_price_sum')
+  rows.value = (data ?? []) as Row[]
+  loading.value = false
+})
+
+function fmtPrice(v: number | null) {
+  return v == null ? '—' : `€${Number(v).toFixed(2)}`
+}
+function fmtInt(v: number | null) {
+  return v == null ? '—' : new Intl.NumberFormat().format(v)
+}
+
+type Col = {
+  key: keyof Row
+  label: string
+  numeric: boolean
+  title?: string
+  format?: (r: Row) => string
+}
+const columns: Col[] = [
+  { key: 'canonical_product_name', label: 'Product', numeric: false },
+  { key: 'unit_symbol', label: 'Unit', numeric: false },
+  { key: 'line_item_count', label: 'Obs.', numeric: true, title: 'Line items observed', format: r => fmtInt(r.line_item_count) },
+  { key: 'receipt_count', label: 'Receipts', numeric: true, title: 'Distinct receipts', format: r => fmtInt(r.receipt_count) },
+  { key: 'store_count', label: 'Stores', numeric: true, title: 'Distinct stores', format: r => fmtInt(r.store_count) },
+  { key: 'retailer_count', label: 'Retailers', numeric: true, title: 'Distinct retailers', format: r => fmtInt(r.retailer_count) },
+  { key: 'median_unit_price', label: 'Median', numeric: true, title: 'Median price per unit', format: r => fmtPrice(r.median_unit_price) },
+  { key: 'min_unit_price', label: 'Min', numeric: true, title: 'Min price per unit', format: r => fmtPrice(r.min_unit_price) },
+  { key: 'max_unit_price', label: 'Max', numeric: true, title: 'Max price per unit', format: r => fmtPrice(r.max_unit_price) },
+  { key: 'total_price_sum', label: 'Total', numeric: true, title: 'Total spent', format: r => fmtPrice(r.total_price_sum) }
+]
+
+const query = ref('')
+const sortKey = ref<keyof Row>('line_item_count')
+const sortDir = ref<'asc' | 'desc'>('desc')
+
+function toggleSort(key: keyof Row) {
+  if (sortKey.value === key) {
+    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortKey.value = key
+    // text defaults to A→Z, numbers to high→low
+    sortDir.value = key === 'canonical_product_name' || key === 'unit_symbol' ? 'asc' : 'desc'
+  }
+}
+
+const filtered = computed(() => {
+  const s = query.value.trim().toLowerCase()
+  if (!s) return rows.value
+  return rows.value.filter(r => r.canonical_product_name.toLowerCase().includes(s))
+})
+
+const sorted = computed(() => {
+  const dir = sortDir.value === 'asc' ? 1 : -1
+  const k = sortKey.value
+  return [...filtered.value].sort((a, b) => {
+    const av = a[k]
+    const bv = b[k]
+    if (typeof av === 'string' && typeof bv === 'string') return av.localeCompare(bv) * dir
+    return (((av as number) ?? 0) - ((bv as number) ?? 0)) * dir
+  })
+})
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center gap-3 mb-3 flex-wrap">
+      <UInput
+        v-model="query"
+        placeholder="Filter products…"
+        icon="i-lucide-search"
+        class="w-64"
+      />
+      <span class="text-sm text-muted">
+        {{ sorted.length }}<span v-if="query"> / {{ rows.length }}</span> products
+      </span>
+      <span class="text-xs text-muted ml-auto">
+        Median / Min / Max are price per unit
+      </span>
+    </div>
+
+    <div v-if="loading" class="flex justify-center py-16">
+      <UIcon name="i-lucide-loader-circle" class="animate-spin text-3xl text-muted" />
+    </div>
+
+    <div v-else class="overflow-x-auto border border-default rounded-xl">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-default bg-elevated/50">
+            <th
+              v-for="col in columns"
+              :key="col.key"
+              scope="col"
+              :title="col.title"
+              class="px-3 py-2.5 font-semibold text-muted whitespace-nowrap cursor-pointer select-none hover:text-default transition-colors"
+              :class="col.numeric ? 'text-right' : 'text-left'"
+              @click="toggleSort(col.key)"
+            >
+              <span class="inline-flex items-center gap-1" :class="col.numeric ? 'flex-row-reverse' : ''">
+                {{ col.label }}
+                <UIcon
+                  v-if="sortKey === col.key"
+                  :name="sortDir === 'asc' ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
+                  class="size-3.5 text-primary"
+                />
+                <UIcon v-else name="i-lucide-chevrons-up-down" class="size-3.5 opacity-30" />
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="row in sorted"
+            :key="row.canonical_product_name + row.unit_symbol"
+            class="border-b border-default last:border-0 hover:bg-elevated/50 transition-colors"
+          >
+            <td
+              v-for="col in columns"
+              :key="col.key"
+              class="px-3 py-2 whitespace-nowrap"
+              :class="[
+                col.numeric ? 'text-right tabular-nums' : 'text-left',
+                col.key === 'canonical_product_name' ? 'font-medium text-highlighted' : '',
+                col.key === 'unit_symbol' ? 'text-muted' : ''
+              ]"
+            >
+              {{ col.format ? col.format(row) : row[col.key] }}
+            </td>
+          </tr>
+          <tr v-if="!sorted.length">
+            <td :colspan="columns.length" class="px-3 py-10 text-center text-muted">
+              No products match “{{ query }}”.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/frontend/app/components/ProductStatsTable.vue
+++ b/frontend/app/components/ProductStatsTable.vue
@@ -53,8 +53,13 @@ const columns: Col[] = [
 ]
 
 const query = ref('')
+const unitFilter = ref('all')
 const sortKey = ref<keyof Row>('line_item_count')
 const sortDir = ref<'asc' | 'desc'>('desc')
+
+const availableUnits = computed(() =>
+  [...new Set(rows.value.map(r => r.unit_symbol).filter(Boolean))].sort()
+)
 
 function toggleSort(key: keyof Row) {
   if (sortKey.value === key) {
@@ -68,8 +73,10 @@ function toggleSort(key: keyof Row) {
 
 const filtered = computed(() => {
   const s = query.value.trim().toLowerCase()
-  if (!s) return rows.value
-  return rows.value.filter(r => r.canonical_product_name.toLowerCase().includes(s))
+  return rows.value.filter(r =>
+    (unitFilter.value === 'all' || r.unit_symbol === unitFilter.value)
+    && (!s || r.canonical_product_name.toLowerCase().includes(s))
+  )
 })
 
 const sorted = computed(() => {
@@ -93,8 +100,26 @@ const sorted = computed(() => {
         icon="i-lucide-search"
         class="w-64"
       />
+      <UButtonGroup size="xs">
+        <UButton
+          :variant="unitFilter === 'all' ? 'solid' : 'outline'"
+          color="neutral"
+          @click="unitFilter = 'all'"
+        >
+          All units
+        </UButton>
+        <UButton
+          v-for="u in availableUnits"
+          :key="u"
+          :variant="unitFilter === u ? 'solid' : 'outline'"
+          color="neutral"
+          @click="unitFilter = u"
+        >
+          {{ u }}
+        </UButton>
+      </UButtonGroup>
       <span class="text-sm text-muted">
-        {{ sorted.length }}<span v-if="query"> / {{ rows.length }}</span> products
+        {{ sorted.length }}<span v-if="sorted.length !== rows.length"> / {{ rows.length }}</span> products
       </span>
       <span class="text-xs text-muted ml-auto">
         Median / Min / Max are price per unit

--- a/frontend/app/pages/data-quality.vue
+++ b/frontend/app/pages/data-quality.vue
@@ -1,0 +1,323 @@
+<script setup lang="ts">
+useSeoMeta({ title: 'Data Quality · cartwatch' })
+
+const supabase = useSupabaseClient()
+
+const euro = (v: any) => (v == null || v === '' ? '—' : `${Number(v) < 0 ? '-' : ''}€${Math.abs(Number(v)).toFixed(2)}`)
+
+function groupByCount(arr: any[], key: string) {
+  const m = new Map<string, number>()
+  for (const x of arr) {
+    const k = x[key] ?? '—'
+    m.set(k, (m.get(k) ?? 0) + 1)
+  }
+  return [...m.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => b.count - a.count)
+}
+
+type CheckResult = {
+  count: number
+  rows: Record<string, any>[]
+  columns: { key: string; label: string; numeric?: boolean; format?: (v: any) => string }[]
+  note?: string
+}
+
+type Check = {
+  id: string
+  title: string
+  description: string
+  severity: 'high' | 'medium' | 'low'
+  run: () => Promise<CheckResult>
+}
+
+const checks: Check[] = [
+  {
+    id: 'unmatched-items',
+    title: 'Unmatched receipt items',
+    description: 'Line items not linked to any canonical product — excluded from price stats.',
+    severity: 'high',
+    run: async () => {
+      const { data, count } = await supabase
+        .from('receipt_items')
+        .select('raw_name', { count: 'exact' })
+        .is('canonical_product_id', null)
+      const grouped = groupByCount(data ?? [], 'raw_name')
+      return {
+        count: count ?? 0,
+        rows: grouped.map(g => ({ name: g.value, n: g.count })),
+        columns: [
+          { key: 'name', label: 'Raw name' },
+          { key: 'n', label: 'Occurrences', numeric: true }
+        ],
+        note: `Grouped by raw name · ${grouped.length} distinct names.`
+      }
+    }
+  },
+  {
+    id: 'mixed-units',
+    title: 'Products with mixed units',
+    description: 'Same product recorded in more than one unit — prices are not comparable.',
+    severity: 'high',
+    run: async () => {
+      const { data } = await supabase
+        .from('mv_product_stats')
+        .select('canonical_product_name, unit_symbol, line_item_count')
+      const byName = new Map<string, Map<string, number>>()
+      for (const r of data ?? []) {
+        if (!r.unit_symbol) continue // a missing unit is its own check
+        const units = byName.get(r.canonical_product_name) ?? new Map<string, number>()
+        units.set(r.unit_symbol, (units.get(r.unit_symbol) ?? 0) + Number(r.line_item_count))
+        byName.set(r.canonical_product_name, units)
+      }
+      const rows = [...byName.entries()]
+        .filter(([, units]) => units.size > 1)
+        .map(([name, units]) => ({
+          name,
+          units: [...units.entries()].map(([u, c]) => `${u} (${c})`).join(', '),
+          n: units.size
+        }))
+        .sort((a, b) => b.n - a.n)
+      return {
+        count: rows.length,
+        rows,
+        columns: [
+          { key: 'name', label: 'Product' },
+          { key: 'units', label: 'Units (observations)' }
+        ]
+      }
+    }
+  },
+  {
+    id: 'bad-price',
+    title: 'Items with invalid prices',
+    description: 'Line items with a missing, zero, or negative price.',
+    severity: 'high',
+    run: async () => {
+      const { data, count } = await supabase
+        .from('receipt_items')
+        .select('raw_name, unit_price, total_price', { count: 'exact' })
+        .or('unit_price.is.null,unit_price.lte.0,total_price.is.null')
+      return {
+        count: count ?? 0,
+        rows: data ?? [],
+        columns: [
+          { key: 'raw_name', label: 'Raw name' },
+          { key: 'unit_price', label: 'Unit', numeric: true, format: euro },
+          { key: 'total_price', label: 'Total', numeric: true, format: euro }
+        ]
+      }
+    }
+  },
+  {
+    id: 'total-mismatch',
+    title: 'Receipt total mismatches',
+    description: 'Receipts whose line items do not sum to the recorded total.',
+    severity: 'high',
+    run: async () => {
+      const { data } = await supabase
+        .from('receipts')
+        .select('purchased_at, total, receipt_items(total_price)')
+      const rows: Record<string, any>[] = []
+      for (const r of data ?? []) {
+        const sum = (r.receipt_items ?? []).reduce((s: number, i: any) => s + Number(i.total_price || 0), 0)
+        const diff = Number(r.total) - sum
+        if (Math.abs(diff) > 0.02) {
+          rows.push({
+            date: new Date(r.purchased_at).toLocaleDateString(),
+            total: Number(r.total),
+            items: sum,
+            diff
+          })
+        }
+      }
+      rows.sort((a, b) => Math.abs(b.diff) - Math.abs(a.diff))
+      return {
+        count: rows.length,
+        rows,
+        columns: [
+          { key: 'date', label: 'Date' },
+          { key: 'total', label: 'Recorded', numeric: true, format: euro },
+          { key: 'items', label: 'Items sum', numeric: true, format: euro },
+          { key: 'diff', label: 'Diff', numeric: true, format: euro }
+        ]
+      }
+    }
+  },
+  {
+    id: 'pending-matches',
+    title: 'Pending product matches',
+    description: 'Items in the reconciliation queue awaiting confirmation.',
+    severity: 'medium',
+    run: async () => {
+      const { data, count } = await supabase
+        .from('product_matches')
+        .select('confidence, matched_by, receipt_items(raw_name), canonical_products(name)', { count: 'exact' })
+        .eq('status', 'pending')
+        .order('confidence', { ascending: true })
+        .limit(200)
+      return {
+        count: count ?? 0,
+        rows: (data ?? []).map((r: any) => ({
+          raw: r.receipt_items?.raw_name ?? '—',
+          suggestion: r.canonical_products?.name ?? '(no match)',
+          confidence: r.confidence,
+          by: r.matched_by
+        })),
+        columns: [
+          { key: 'raw', label: 'Raw name' },
+          { key: 'suggestion', label: 'Suggested' },
+          { key: 'confidence', label: 'Confidence', numeric: true, format: v => Number(v).toFixed(2) },
+          { key: 'by', label: 'By' }
+        ],
+        note: 'Sorted by lowest confidence first.'
+      }
+    }
+  },
+  {
+    id: 'products-no-unit',
+    title: 'Products without a unit',
+    description: 'Canonical products with no unit set — prices cannot be normalised.',
+    severity: 'medium',
+    run: async () => {
+      const { data, count } = await supabase
+        .from('canonical_products')
+        .select('name, short_name', { count: 'exact' })
+        .is('unit_id', null)
+        .order('name')
+      return {
+        count: count ?? 0,
+        rows: data ?? [],
+        columns: [
+          { key: 'name', label: 'Product' },
+          { key: 'short_name', label: 'Short name' }
+        ]
+      }
+    }
+  },
+  {
+    id: 'items-no-unit',
+    title: 'Items without a unit',
+    description: 'Receipt line items missing a unit symbol.',
+    severity: 'medium',
+    run: async () => {
+      const { data, count } = await supabase
+        .from('receipt_items')
+        .select('raw_name', { count: 'exact' })
+        .is('unit_id', null)
+      const grouped = groupByCount(data ?? [], 'raw_name')
+      return {
+        count: count ?? 0,
+        rows: grouped.map(g => ({ name: g.value, n: g.count })),
+        columns: [
+          { key: 'name', label: 'Raw name' },
+          { key: 'n', label: 'Occurrences', numeric: true }
+        ]
+      }
+    }
+  },
+  {
+    id: 'products-no-category',
+    title: 'Products without a category',
+    description: 'Canonical products not assigned to a category.',
+    severity: 'low',
+    run: async () => {
+      const { data, count } = await supabase
+        .from('canonical_products')
+        .select('name, short_name', { count: 'exact' })
+        .is('category_id', null)
+        .order('name')
+      return {
+        count: count ?? 0,
+        rows: data ?? [],
+        columns: [
+          { key: 'name', label: 'Product' },
+          { key: 'short_name', label: 'Short name' }
+        ]
+      }
+    }
+  },
+  {
+    id: 'stores-no-chain',
+    title: 'Stores without a chain',
+    description: 'Stores not linked to a retailer chain.',
+    severity: 'low',
+    run: async () => {
+      const { data, count } = await supabase
+        .from('stores')
+        .select('name, city', { count: 'exact' })
+        .is('chain_id', null)
+        .order('name')
+      return {
+        count: count ?? 0,
+        rows: data ?? [],
+        columns: [
+          { key: 'name', label: 'Store' },
+          { key: 'city', label: 'City' }
+        ]
+      }
+    }
+  }
+]
+
+type State = { count: number | null; rows: any[]; columns: any[]; note?: string; loading: boolean }
+const state = reactive<Record<string, State>>(
+  Object.fromEntries(checks.map(c => [c.id, { count: null, rows: [], columns: [], loading: true }]))
+)
+
+onMounted(() => {
+  for (const c of checks) {
+    c.run()
+      .then((res) => {
+        state[c.id] = { ...res, loading: false }
+      })
+      .catch((err) => {
+        console.error(`[data-quality] ${c.id} failed`, err)
+        state[c.id].loading = false
+      })
+  }
+})
+
+const anyLoading = computed(() => checks.some(c => state[c.id].loading))
+const flaggedCount = computed(() => checks.filter(c => (state[c.id].count ?? 0) > 0).length)
+</script>
+
+<template>
+  <UContainer class="py-8 max-w-4xl">
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold mb-1">
+        Data Quality
+      </h1>
+      <p class="text-muted text-sm">
+        Issues that affect the accuracy of the dashboards. Expand a card to see the affected records.
+      </p>
+    </div>
+
+    <div class="mb-5 flex items-center gap-2 text-sm">
+      <UIcon v-if="anyLoading" name="i-lucide-loader-circle" class="animate-spin text-muted" />
+      <template v-else-if="flaggedCount === 0">
+        <UIcon name="i-lucide-circle-check" class="text-success" />
+        <span>All {{ checks.length }} checks passed.</span>
+      </template>
+      <template v-else>
+        <UIcon name="i-lucide-triangle-alert" class="text-warning" />
+        <span><strong>{{ flaggedCount }}</strong> of {{ checks.length }} checks flagged issues.</span>
+      </template>
+    </div>
+
+    <div class="space-y-3">
+      <DataQualityCard
+        v-for="c in checks"
+        :key="c.id"
+        :title="c.title"
+        :description="c.description"
+        :severity="c.severity"
+        :count="state[c.id].count"
+        :loading="state[c.id].loading"
+        :rows="state[c.id].rows"
+        :columns="state[c.id].columns"
+        :note="state[c.id].note"
+      />
+    </div>
+  </UContainer>
+</template>

--- a/frontend/app/pages/data-quality.vue
+++ b/frontend/app/pages/data-quality.vue
@@ -41,6 +41,7 @@ const checks: Check[] = [
       const { data, count } = await supabase
         .from('receipt_items')
         .select('raw_name', { count: 'exact' })
+        .is('ignore', null)
         .is('canonical_product_id', null)
       const grouped = groupByCount(data ?? [], 'raw_name')
       return {
@@ -175,27 +176,6 @@ const checks: Check[] = [
     }
   },
   {
-    id: 'products-no-unit',
-    title: 'Products without a unit',
-    description: 'Canonical products with no unit set — prices cannot be normalised.',
-    severity: 'medium',
-    run: async () => {
-      const { data, count } = await supabase
-        .from('canonical_products')
-        .select('name, short_name', { count: 'exact' })
-        .is('unit_id', null)
-        .order('name')
-      return {
-        count: count ?? 0,
-        rows: data ?? [],
-        columns: [
-          { key: 'name', label: 'Product' },
-          { key: 'short_name', label: 'Short name' }
-        ]
-      }
-    }
-  },
-  {
     id: 'items-no-unit',
     title: 'Items without a unit',
     description: 'Receipt line items missing a unit symbol.',
@@ -246,6 +226,7 @@ const checks: Check[] = [
       const { data, count } = await supabase
         .from('stores')
         .select('name, city', { count: 'exact' })
+        .is('ignore', null)
         .is('chain_id', null)
         .order('name')
       return {

--- a/frontend/app/pages/data-quality.vue
+++ b/frontend/app/pages/data-quality.vue
@@ -98,6 +98,7 @@ const checks: Check[] = [
       const { data, count } = await supabase
         .from('receipt_items')
         .select('raw_name, unit_price, total_price', { count: 'exact' })
+        .is('ignore', null)
         .or('unit_price.is.null,unit_price.lte.0,total_price.is.null')
       return {
         count: count ?? 0,
@@ -119,6 +120,7 @@ const checks: Check[] = [
       const { data } = await supabase
         .from('receipts')
         .select('purchased_at, total, receipt_items(total_price)')
+        .is('receipt_items(ignore)', null)
       const rows: Record<string, any>[] = []
       for (const r of data ?? []) {
         const sum = (r.receipt_items ?? []).reduce((s: number, i: any) => s + Number(i.total_price || 0), 0)
@@ -184,6 +186,7 @@ const checks: Check[] = [
       const { data, count } = await supabase
         .from('receipt_items')
         .select('raw_name', { count: 'exact' })
+        .is('ignore', null)
         .is('unit_id', null)
       const grouped = groupByCount(data ?? [], 'raw_name')
       return {

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -1,76 +1,12 @@
 <template>
-  <div>
-    <UPageHero
-      title="Nuxt Starter Template"
-      description="A production-ready starter template powered by Nuxt UI. Build beautiful, accessible, and performant applications in minutes, not hours."
-      :links="[{
-        label: 'Get started',
-        to: 'https://ui.nuxt.com/docs/getting-started/installation/nuxt',
-        target: '_blank',
-        trailingIcon: 'i-lucide-arrow-right',
-        size: 'xl'
-      }, {
-        label: 'Use this template',
-        to: 'https://github.com/nuxt-ui-templates/starter',
-        target: '_blank',
-        icon: 'i-simple-icons-github',
-        size: 'xl',
-        color: 'neutral',
-        variant: 'subtle'
-      }]"
-    />
-
-    <UPageSection
-      id="features"
-      title="Everything you need to build modern Nuxt apps"
-      description="Start with a solid foundation. This template includes all the essentials for building production-ready applications with Nuxt UI's powerful component system."
-      :features="[{
-        icon: 'i-lucide-rocket',
-        title: 'Production-ready from day one',
-        description: 'Pre-configured with TypeScript, ESLint, Tailwind CSS, and all the best practices. Focus on building features, not setting up tooling.'
-      }, {
-        icon: 'i-lucide-palette',
-        title: 'Beautiful by default',
-        description: 'Leveraging Nuxt UI\'s design system with automatic dark mode, consistent spacing, and polished components that look great out of the box.'
-      }, {
-        icon: 'i-lucide-zap',
-        title: 'Lightning fast',
-        description: 'Optimized for performance with SSR/SSG support, automatic code splitting, and edge-ready deployment. Your users will love the speed.'
-      }, {
-        icon: 'i-lucide-blocks',
-        title: '100+ components included',
-        description: 'Access Nuxt UI\'s comprehensive component library. From forms to navigation, everything is accessible, responsive, and customizable.'
-      }, {
-        icon: 'i-lucide-code-2',
-        title: 'Developer experience first',
-        description: 'Auto-imports, hot module replacement, and TypeScript support. Write less boilerplate and ship more features.'
-      }, {
-        icon: 'i-lucide-shield-check',
-        title: 'Built for scale',
-        description: 'Enterprise-ready architecture with proper error handling, SEO optimization, and security best practices built-in.'
-      }]"
-    />
-
-    <UPageSection>
-      <UPageCTA
-        title="Ready to build your next Nuxt app?"
-        description="Join thousands of developers building with Nuxt and Nuxt UI. Get this template and start shipping today."
-        variant="subtle"
-        :links="[{
-          label: 'Start building',
-          to: 'https://ui.nuxt.com/docs/getting-started/installation/nuxt',
-          target: '_blank',
-          trailingIcon: 'i-lucide-arrow-right',
-          color: 'neutral'
-        }, {
-          label: 'View on GitHub',
-          to: 'https://github.com/nuxt-ui-templates/starter',
-          target: '_blank',
-          icon: 'i-simple-icons-github',
-          color: 'neutral',
-          variant: 'outline'
-        }]"
-      />
-    </UPageSection>
-  </div>
+  <UPageHero
+    title="cartwatch"
+    description="Track grocery prices across stores. See how your basket cost changes over time."
+    :links="[{
+      label: 'Price History',
+      to: '/prices',
+      trailingIcon: 'i-lucide-trending-up',
+      size: 'xl'
+    }]"
+  />
 </template>

--- a/frontend/app/pages/prices.vue
+++ b/frontend/app/pages/prices.vue
@@ -9,14 +9,18 @@ const query = ref('')
 const searchResults = ref<ProductHit[]>([])
 const searching = ref(false)
 
-// Persisted list of charts (one per product), kept in this browser.
+// Persisted state, kept in this browser.
 const STORAGE_KEY = 'cartwatch:price-charts'
+const PERROW_KEY = 'cartwatch:charts-per-row'
 const products = ref<ProductHit[]>([])
+const perRow = ref(1)
 
 onMounted(() => {
   try {
     const saved = localStorage.getItem(STORAGE_KEY)
     if (saved) products.value = JSON.parse(saved)
+    const savedPerRow = Number(localStorage.getItem(PERROW_KEY))
+    if (savedPerRow >= 1 && savedPerRow <= 3) perRow.value = savedPerRow
   } catch {
     // ignore malformed storage
   }
@@ -25,6 +29,10 @@ onMounted(() => {
 watch(products, (val) => {
   if (import.meta.client) localStorage.setItem(STORAGE_KEY, JSON.stringify(val))
 }, { deep: true })
+
+watch(perRow, (val) => {
+  if (import.meta.client) localStorage.setItem(PERROW_KEY, String(val))
+})
 
 const addedIds = computed(() => new Set(products.value.map(p => p.id)))
 
@@ -60,17 +68,17 @@ function removeProduct(id: string) {
 </script>
 
 <template>
-  <UContainer class="py-8 max-w-4xl">
+  <UContainer class="py-8" :class="perRow === 1 ? 'max-w-4xl' : 'max-w-7xl'">
     <div class="mb-6">
       <h1 class="text-2xl font-bold mb-1">
         Price History
       </h1>
       <p class="text-muted text-sm">
-        Add a chart per product to compare price trends across stores. Your charts are saved in this browser.
+        Add a chart per product to compare price trends across stores. Your layout is saved in this browser.
       </p>
     </div>
 
-    <div class="relative mb-8">
+    <div class="relative mb-6">
       <UInput
         v-model="query"
         placeholder="Search products to add a chart… e.g. milk, eggs"
@@ -104,7 +112,26 @@ function removeProduct(id: string) {
       </div>
     </div>
 
-    <div v-if="products.length" class="space-y-6">
+    <div v-if="products.length" class="flex items-center justify-end gap-2 mb-4">
+      <span class="text-sm text-muted">Charts per row</span>
+      <UButtonGroup size="xs">
+        <UButton
+          v-for="n in [1, 2, 3]"
+          :key="n"
+          :variant="perRow === n ? 'solid' : 'outline'"
+          color="neutral"
+          @click="perRow = n"
+        >
+          {{ n }}
+        </UButton>
+      </UButtonGroup>
+    </div>
+
+    <div
+      v-if="products.length"
+      class="grid gap-6"
+      :style="{ gridTemplateColumns: `repeat(${perRow}, minmax(0, 1fr))` }"
+    >
       <ProductChart
         v-for="product in products"
         :key="product.id"

--- a/frontend/app/pages/prices.vue
+++ b/frontend/app/pages/prices.vue
@@ -1,0 +1,282 @@
+<script setup lang="ts">
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  TimeScale
+} from 'chart.js'
+import 'chartjs-adapter-date-fns'
+import { Line } from 'vue-chartjs'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, TimeScale)
+
+useSeoMeta({ title: 'Price History · cartwatch' })
+
+const supabase = useSupabaseClient()
+
+type ProductHit = { id: string; name: string; short_name: string; unit: string | null }
+
+const query = ref('')
+const selectedProduct = ref<ProductHit | null>(null)
+const searchResults = ref<ProductHit[]>([])
+const searching = ref(false)
+const loadingHistory = ref(false)
+
+type PricePoint = {
+  date: string
+  unit_price: number
+  store_chain: string
+  raw_name: string
+  quantity: number
+  item_unit: string
+  currency: string
+}
+const history = ref<PricePoint[]>([])
+
+const CHAIN_COLORS: Record<string, string> = {
+  REWE: '#e2001a',
+  Lidl: '#0050aa',
+  'Aldi Süd': '#00519e',
+  'Aldi Nord': '#003087',
+  Edeka: '#f5a800',
+  Penny: '#c8102e',
+  Netto: '#ffd100',
+  Kaufland: '#e2001a',
+  dm: '#d40511',
+  Rossmann: '#e2001a',
+  Amazon: '#ff9900',
+  Other: '#94a3b8'
+}
+
+const CURRENCY_SYMBOLS: Record<string, string> = { EUR: '€', USD: '$', GBP: '£' }
+
+async function searchProducts() {
+  if (query.value.length < 2) {
+    searchResults.value = []
+    return
+  }
+  searching.value = true
+  const { data } = await supabase
+    .from('canonical_products')
+    .select('id, name, short_name, units ( symbol )')
+    .ilike('name', `%${query.value}%`)
+    .limit(10)
+  searchResults.value = (data ?? []).map((r: any) => ({
+    id: r.id,
+    name: r.name,
+    short_name: r.short_name,
+    unit: r.units?.symbol ?? null
+  }))
+  searching.value = false
+}
+
+async function selectProduct(product: ProductHit) {
+  selectedProduct.value = product
+  query.value = product.name
+  searchResults.value = []
+  await loadHistory(product.id)
+}
+
+async function loadHistory(productId: string) {
+  loadingHistory.value = true
+  history.value = []
+
+  const { data } = await supabase
+    .from('receipt_items')
+    .select(`
+      raw_name,
+      quantity,
+      unit_price,
+      units ( symbol ),
+      receipts!inner (
+        purchased_at,
+        currency,
+        stores!inner (
+          store_chains!inner ( name )
+        )
+      )
+    `)
+    .eq('canonical_product_id', productId)
+    .order('receipts(purchased_at)', { ascending: true })
+
+  if (data) {
+    history.value = data.map((row: any) => ({
+      date: row.receipts.purchased_at,
+      unit_price: row.unit_price,
+      store_chain: row.receipts.stores.store_chains.name,
+      raw_name: row.raw_name,
+      quantity: row.quantity,
+      item_unit: row.units?.symbol ?? '',
+      currency: row.receipts.currency
+    }))
+  }
+  loadingHistory.value = false
+}
+
+const currencySymbol = computed(() => {
+  const c = history.value[0]?.currency ?? 'EUR'
+  return CURRENCY_SYMBOLS[c] ?? `${c} `
+})
+
+// Distinct units actually present across the receipt items for this product.
+const distinctUnits = computed(() =>
+  [...new Set(history.value.map(p => p.item_unit).filter(Boolean))]
+)
+
+// Prefer the canonical product's unit; fall back to the item unit only when unambiguous.
+const displayUnit = computed(() =>
+  selectedProduct.value?.unit ?? (distinctUnits.value.length === 1 ? distinctUnits.value[0]! : null)
+)
+
+// True when there's no canonical unit and items disagree — prices aren't comparable yet.
+const unitsMixed = computed(() =>
+  !selectedProduct.value?.unit && distinctUnits.value.length > 1
+)
+
+const yAxisLabel = computed(() =>
+  `Price (${currencySymbol.value}${displayUnit.value ? ` / ${displayUnit.value}` : ''})`
+)
+
+const chartData = computed(() => {
+  const chains = [...new Set(history.value.map(p => p.store_chain))]
+  return {
+    datasets: chains.map(chain => ({
+      label: chain,
+      data: history.value
+        .filter(p => p.store_chain === chain)
+        .map(p => ({ x: new Date(p.date).getTime(), y: p.unit_price, meta: p })),
+      borderColor: CHAIN_COLORS[chain] ?? '#94a3b8',
+      backgroundColor: (CHAIN_COLORS[chain] ?? '#94a3b8') + '33',
+      tension: 0.3,
+      pointRadius: 4,
+      pointHoverRadius: 6
+    }))
+  }
+})
+
+const chartOptions = computed(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  interaction: { mode: 'nearest' as const, intersect: true },
+  scales: {
+    x: {
+      type: 'time' as const,
+      time: { unit: 'month' as const },
+      title: { display: true, text: 'Date' }
+    },
+    y: {
+      title: { display: true, text: yAxisLabel.value },
+      ticks: { callback: (v: any) => `${currencySymbol.value}${Number(v).toFixed(2)}` }
+    }
+  },
+  plugins: {
+    legend: { position: 'bottom' as const },
+    tooltip: {
+      callbacks: {
+        // Full original receipt name as the tooltip heading.
+        title: (items: any[]) => items[0]?.raw?.meta?.raw_name ?? '',
+        label: (ctx: any) => {
+          const m = ctx.raw.meta as PricePoint
+          const unit = displayUnit.value ?? m.item_unit
+          return `${ctx.dataset.label}: ${currencySymbol.value}${ctx.parsed.y.toFixed(2)}${unit ? ` / ${unit}` : ''}`
+        },
+        afterLabel: (ctx: any) => {
+          const m = ctx.raw.meta as PricePoint
+          const date = new Date(m.date).toLocaleDateString()
+          const qty = `Qty: ${m.quantity}${m.item_unit ? ` ${m.item_unit}` : ''}`
+          return [qty, date]
+        }
+      }
+    }
+  }
+}))
+</script>
+
+<template>
+  <UContainer class="py-8 max-w-4xl">
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold mb-1">
+        Price History
+      </h1>
+      <p class="text-muted text-sm">
+        Search for a product to see how its price has evolved across stores.
+      </p>
+    </div>
+
+    <div class="relative mb-8">
+      <UInput
+        v-model="query"
+        placeholder="Search products… e.g. milk, eggs"
+        icon="i-lucide-search"
+        size="lg"
+        class="w-full"
+        :loading="searching"
+        @input="searchProducts"
+      />
+      <div
+        v-if="searchResults.length"
+        class="absolute z-10 w-full mt-1 bg-background border border-default rounded-lg shadow-lg overflow-hidden"
+      >
+        <button
+          v-for="product in searchResults"
+          :key="product.id"
+          class="w-full text-left px-4 py-2.5 hover:bg-elevated flex items-center gap-3 transition-colors"
+          @click="selectProduct(product)"
+        >
+          <UIcon name="i-lucide-package" class="text-muted shrink-0" />
+          <span>{{ product.name }}</span>
+          <span class="text-muted text-sm ml-auto">{{ product.short_name }}</span>
+        </button>
+      </div>
+    </div>
+
+    <div v-if="loadingHistory" class="flex justify-center py-16">
+      <UIcon name="i-lucide-loader-circle" class="animate-spin text-3xl text-muted" />
+    </div>
+
+    <template v-else-if="selectedProduct && history.length">
+      <div class="mb-3 flex flex-wrap items-center gap-2">
+        <UBadge variant="subtle">
+          {{ history.length }} data points
+        </UBadge>
+        <span class="text-muted text-sm">for <strong>{{ selectedProduct.name }}</strong></span>
+        <UBadge
+          v-if="displayUnit && !unitsMixed"
+          color="neutral"
+          variant="outline"
+        >
+          {{ currencySymbol }} / {{ displayUnit }}
+        </UBadge>
+        <UBadge
+          v-if="unitsMixed"
+          color="warning"
+          variant="subtle"
+          icon="i-lucide-triangle-alert"
+        >
+          Mixed units: {{ distinctUnits.join(', ') }} — prices not comparable
+        </UBadge>
+      </div>
+      <div class="h-80 border border-default rounded-xl p-4 bg-background">
+        <Line :data="chartData" :options="chartOptions" />
+      </div>
+    </template>
+
+    <div
+      v-else-if="selectedProduct && !loadingHistory"
+      class="text-center py-16 text-muted"
+    >
+      <UIcon name="i-lucide-inbox" class="text-4xl mb-2" />
+      <p>No price history found for <strong>{{ selectedProduct.name }}</strong>.</p>
+    </div>
+
+    <div v-else-if="!selectedProduct" class="text-center py-16 text-muted">
+      <UIcon name="i-lucide-trending-up" class="text-4xl mb-2" />
+      <p>Search for a product above to see its price history.</p>
+    </div>
+  </UContainer>
+</template>

--- a/frontend/app/pages/prices.vue
+++ b/frontend/app/pages/prices.vue
@@ -3,27 +3,56 @@ useSeoMeta({ title: 'Price History · cartwatch' })
 
 const supabase = useSupabaseClient()
 
-type ProductHit = { id: string; name: string; short_name: string; unit: string | null }
+type ProductHit = { id: string; name: string; short_name: string; unit: string | null; obs?: number }
 
 const query = ref('')
-const searchResults = ref<ProductHit[]>([])
-const searching = ref(false)
+const focused = ref(false)
 
 // Persisted state, kept in this browser.
 const STORAGE_KEY = 'cartwatch:price-charts'
 const PERROW_KEY = 'cartwatch:charts-per-row'
+const JITTER_KEY = 'cartwatch:jitter'
+const MINOBS_KEY = 'cartwatch:min-obs'
 const products = ref<ProductHit[]>([])
 const perRow = ref(1)
+const jitter = ref(true)
+const minObs = ref(5)
 
-onMounted(() => {
+// Every product with its observation count, most-observed first — powers an
+// instant, browsable dropdown so you can pick without typing an exact name.
+const allProducts = ref<ProductHit[]>([])
+
+onMounted(async () => {
   try {
     const saved = localStorage.getItem(STORAGE_KEY)
     if (saved) products.value = JSON.parse(saved)
     const savedPerRow = Number(localStorage.getItem(PERROW_KEY))
     if (savedPerRow >= 1 && savedPerRow <= 3) perRow.value = savedPerRow
+    const savedJitter = localStorage.getItem(JITTER_KEY)
+    if (savedJitter !== null) jitter.value = savedJitter === 'true'
+    const savedMinObs = Number(localStorage.getItem(MINOBS_KEY))
+    if (Number.isFinite(savedMinObs) && savedMinObs >= 0) minObs.value = savedMinObs
   } catch {
     // ignore malformed storage
   }
+
+  const [{ data: stats }, { data: prods }] = await Promise.all([
+    supabase.from('mv_product_stats').select('canonical_product_name, line_item_count'),
+    supabase.from('canonical_products').select('id, name, short_name, units ( symbol )')
+  ])
+  const obs = new Map<string, number>()
+  for (const r of stats ?? []) {
+    obs.set(r.canonical_product_name, (obs.get(r.canonical_product_name) ?? 0) + Number(r.line_item_count))
+  }
+  allProducts.value = (prods ?? [])
+    .map((r: any) => ({
+      id: r.id,
+      name: r.name,
+      short_name: r.short_name,
+      unit: r.units?.symbol ?? null,
+      obs: obs.get(r.name) ?? 0
+    }))
+    .sort((a, b) => (b.obs ?? 0) - (a.obs ?? 0))
 })
 
 watch(products, (val) => {
@@ -34,36 +63,77 @@ watch(perRow, (val) => {
   if (import.meta.client) localStorage.setItem(PERROW_KEY, String(val))
 })
 
+watch(jitter, (val) => {
+  if (import.meta.client) localStorage.setItem(JITTER_KEY, String(val))
+})
+
+watch(minObs, (val) => {
+  if (import.meta.client) localStorage.setItem(MINOBS_KEY, String(val))
+})
+
 const addedIds = computed(() => new Set(products.value.map(p => p.id)))
 
-async function searchProducts() {
-  if (query.value.length < 2) {
-    searchResults.value = []
-    return
-  }
-  searching.value = true
-  const { data } = await supabase
-    .from('canonical_products')
-    .select('id, name, short_name, units ( symbol )')
-    .ilike('name', `%${query.value}%`)
-    .limit(10)
-  searchResults.value = (data ?? []).map((r: any) => ({
-    id: r.id,
-    name: r.name,
-    short_name: r.short_name,
-    unit: r.units?.symbol ?? null
-  }))
-  searching.value = false
-}
+// Instant client-side search: keep products above the min-obs threshold, then
+// match the typed query; with no query it lists the most-observed products.
+const searchResults = computed(() => {
+  const q = query.value.trim().toLowerCase()
+  return allProducts.value
+    .filter(p => (p.obs ?? 0) >= minObs.value)
+    .filter(p => !q || p.name.toLowerCase().includes(q))
+    .slice(0, 12)
+})
 
 function addProduct(product: ProductHit) {
   if (!addedIds.value.has(product.id)) products.value.push(product)
   query.value = ''
-  searchResults.value = []
+  focused.value = false
 }
 
 function removeProduct(id: string) {
   products.value = products.value.filter(p => p.id !== id)
+}
+
+function onSearchBlur() {
+  // delay so a click on a result registers before the dropdown closes
+  setTimeout(() => { focused.value = false }, 150)
+}
+
+// Keyboard navigation of the search dropdown.
+const highlightedIndex = ref(0)
+const dropdownEl = ref<HTMLElement | null>(null)
+
+watch(searchResults, () => { highlightedIndex.value = 0 })
+watch(highlightedIndex, (i) => {
+  nextTick(() => {
+    const el = dropdownEl.value?.children?.[i] as HTMLElement | undefined
+    el?.scrollIntoView({ block: 'nearest' })
+  })
+})
+
+function onSearchKeydown(e: KeyboardEvent) {
+  const n = searchResults.value.length
+  if (!focused.value || !n) return
+  if (e.key === 'ArrowDown') {
+    e.preventDefault()
+    highlightedIndex.value = (highlightedIndex.value + 1) % n
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault()
+    highlightedIndex.value = (highlightedIndex.value - 1 + n) % n
+  } else if (e.key === 'Enter') {
+    e.preventDefault()
+    const p = searchResults.value[highlightedIndex.value]
+    if (p && !addedIds.value.has(p.id)) addProduct(p)
+  } else if (e.key === 'Tab') {
+    // autocomplete the box to the highlighted product's name
+    const p = searchResults.value[highlightedIndex.value]
+    if (p && query.value.trim() && p.name !== query.value) {
+      e.preventDefault()
+      query.value = p.name
+    }
+  } else if (e.key === 'Escape') {
+    focused.value = false
+    ;(e.target as HTMLElement).blur()
+  }
 }
 
 // ── drag-and-drop reorder ───────────────────────────────────────────────
@@ -100,7 +170,7 @@ function onDragEnd() {
 </script>
 
 <template>
-  <UContainer class="py-8" :class="perRow === 1 ? 'max-w-4xl' : 'max-w-7xl'">
+  <UContainer class="py-8 max-w-7xl">
     <div class="mb-6">
       <h1 class="text-2xl font-bold mb-1">
         Price History
@@ -110,80 +180,111 @@ function onDragEnd() {
       </p>
     </div>
 
-    <div class="relative mb-6">
-      <UInput
-        v-model="query"
-        placeholder="Search products to add a chart… e.g. milk, eggs"
-        icon="i-lucide-search"
-        size="lg"
-        class="w-full"
-        :loading="searching"
-        @input="searchProducts"
-      />
-      <div
-        v-if="searchResults.length"
-        class="absolute z-10 w-full mt-1 bg-background border border-default rounded-lg shadow-lg overflow-hidden"
-      >
-        <button
-          v-for="product in searchResults"
-          :key="product.id"
-          class="w-full text-left px-4 py-2.5 hover:bg-elevated flex items-center gap-3 transition-colors disabled:opacity-50"
-          :disabled="addedIds.has(product.id)"
-          @click="addProduct(product)"
-        >
-          <UIcon name="i-lucide-package" class="text-muted shrink-0" />
-          <span>{{ product.name }}</span>
-          <span
-            v-if="addedIds.has(product.id)"
-            class="ml-auto text-xs text-primary flex items-center gap-1"
+    <div class="flex flex-col lg:flex-row gap-6 items-start">
+      <!-- filters sidebar -->
+      <aside class="w-full lg:w-72 shrink-0 space-y-5 lg:sticky lg:top-24">
+        <div class="relative">
+          <UInput
+            v-model="query"
+            placeholder="Search or browse products…"
+            icon="i-lucide-search"
+            class="w-full"
+            @focus="focused = true"
+            @blur="onSearchBlur"
+            @keydown="onSearchKeydown"
+          />
+          <div
+            v-if="focused && searchResults.length"
+            ref="dropdownEl"
+            class="absolute z-20 w-full mt-1 bg-default border border-default rounded-lg shadow-lg overflow-hidden max-h-96 overflow-y-auto"
           >
-            <UIcon name="i-lucide-check" /> added
-          </span>
-          <span v-else class="text-muted text-sm ml-auto">{{ product.short_name }}</span>
-        </button>
-      </div>
-    </div>
+            <button
+              v-for="(product, i) in searchResults"
+              :key="product.id"
+              class="w-full text-left px-3 py-2 flex items-center gap-2 transition-colors disabled:opacity-50"
+              :class="i === highlightedIndex ? 'bg-elevated' : ''"
+              :disabled="addedIds.has(product.id)"
+              @mouseenter="highlightedIndex = i"
+              @click="addProduct(product)"
+            >
+              <UIcon name="i-lucide-package" class="text-muted shrink-0" />
+              <span class="truncate">{{ product.name }}</span>
+              <UBadge color="neutral" variant="subtle" size="sm" class="ml-auto shrink-0">
+                {{ product.obs }} obs
+              </UBadge>
+              <UIcon
+                v-if="addedIds.has(product.id)"
+                name="i-lucide-check"
+                class="text-primary shrink-0"
+              />
+            </button>
+          </div>
+        </div>
 
-    <div v-if="products.length" class="flex items-center justify-end gap-2 mb-4">
-      <span class="text-sm text-muted">Charts per row</span>
-      <UButtonGroup size="xs">
-        <UButton
-          v-for="n in [1, 2, 3]"
-          :key="n"
-          :variant="perRow === n ? 'solid' : 'outline'"
-          color="neutral"
-          @click="perRow = n"
+        <div>
+          <label class="block text-xs text-muted mb-1">Min. observations</label>
+          <UInput
+            v-model.number="minObs"
+            type="number"
+            :min="0"
+            class="w-full"
+          />
+        </div>
+
+        <div class="flex items-center justify-between">
+          <span class="text-sm text-muted">Jitter dots</span>
+          <USwitch v-model="jitter" size="sm" />
+        </div>
+
+        <div class="flex items-center justify-between">
+          <span class="text-sm text-muted">Charts per row</span>
+          <UButtonGroup size="xs">
+            <UButton
+              v-for="n in [1, 2, 3]"
+              :key="n"
+              :variant="perRow === n ? 'solid' : 'outline'"
+              color="neutral"
+              @click="perRow = n"
+            >
+              {{ n }}
+            </UButton>
+          </UButtonGroup>
+        </div>
+      </aside>
+
+      <!-- charts -->
+      <div class="flex-1 min-w-0 w-full">
+        <div
+          v-if="products.length"
+          class="grid gap-6"
+          :style="{ gridTemplateColumns: `repeat(${perRow}, minmax(0, 1fr))` }"
         >
-          {{ n }}
-        </UButton>
-      </UButtonGroup>
-    </div>
+          <div
+            v-for="(product, i) in products"
+            :key="product.id"
+            class="chart-cell transition-opacity"
+            :class="{ 'opacity-40': dragFromIndex === i }"
+            @dragstart="onDragStart(i, $event)"
+            @dragend="onDragEnd"
+            @dragover="onDragOver"
+            @drop="onDrop(i)"
+          >
+            <ProductChart
+              :product="product"
+              :jitter="jitter"
+              @remove="removeProduct(product.id)"
+            />
+          </div>
+        </div>
 
-    <div
-      v-if="products.length"
-      class="grid gap-6"
-      :style="{ gridTemplateColumns: `repeat(${perRow}, minmax(0, 1fr))` }"
-    >
-      <div
-        v-for="(product, i) in products"
-        :key="product.id"
-        class="chart-cell transition-opacity"
-        :class="{ 'opacity-40': dragFromIndex === i }"
-        @dragstart="onDragStart(i, $event)"
-        @dragend="onDragEnd"
-        @dragover="onDragOver"
-        @drop="onDrop(i)"
-      >
-        <ProductChart
-          :product="product"
-          @remove="removeProduct(product.id)"
-        />
+        <div
+          v-else
+          class="text-center py-16 text-muted border border-dashed border-default rounded-xl"
+        >
+          <UIcon name="i-lucide-line-chart" class="text-4xl mb-2" />
+          <p>Search or browse in the sidebar to add your first chart.</p>
+        </div>
       </div>
-    </div>
-
-    <div v-else class="text-center py-16 text-muted">
-      <UIcon name="i-lucide-line-chart" class="text-4xl mb-2" />
-      <p>Search for a product above to add your first chart.</p>
     </div>
   </UContainer>
 </template>

--- a/frontend/app/pages/prices.vue
+++ b/frontend/app/pages/prices.vue
@@ -1,20 +1,4 @@
 <script setup lang="ts">
-import {
-  Chart as ChartJS,
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  LineElement,
-  Title,
-  Tooltip,
-  Legend,
-  TimeScale
-} from 'chart.js'
-import 'chartjs-adapter-date-fns'
-import { Line } from 'vue-chartjs'
-
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, TimeScale)
-
 useSeoMeta({ title: 'Price History · cartwatch' })
 
 const supabase = useSupabaseClient()
@@ -22,38 +6,27 @@ const supabase = useSupabaseClient()
 type ProductHit = { id: string; name: string; short_name: string; unit: string | null }
 
 const query = ref('')
-const selectedProduct = ref<ProductHit | null>(null)
 const searchResults = ref<ProductHit[]>([])
 const searching = ref(false)
-const loadingHistory = ref(false)
 
-type PricePoint = {
-  date: string
-  unit_price: number
-  store_chain: string
-  raw_name: string
-  quantity: number
-  item_unit: string
-  currency: string
-}
-const history = ref<PricePoint[]>([])
+// Persisted list of charts (one per product), kept in this browser.
+const STORAGE_KEY = 'cartwatch:price-charts'
+const products = ref<ProductHit[]>([])
 
-const CHAIN_COLORS: Record<string, string> = {
-  REWE: '#e2001a',
-  Lidl: '#0050aa',
-  'Aldi Süd': '#00519e',
-  'Aldi Nord': '#003087',
-  Edeka: '#f5a800',
-  Penny: '#c8102e',
-  Netto: '#ffd100',
-  Kaufland: '#e2001a',
-  dm: '#d40511',
-  Rossmann: '#e2001a',
-  Amazon: '#ff9900',
-  Other: '#94a3b8'
-}
+onMounted(() => {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) products.value = JSON.parse(saved)
+  } catch {
+    // ignore malformed storage
+  }
+})
 
-const CURRENCY_SYMBOLS: Record<string, string> = { EUR: '€', USD: '$', GBP: '£' }
+watch(products, (val) => {
+  if (import.meta.client) localStorage.setItem(STORAGE_KEY, JSON.stringify(val))
+}, { deep: true })
+
+const addedIds = computed(() => new Set(products.value.map(p => p.id)))
 
 async function searchProducts() {
   if (query.value.length < 2) {
@@ -75,126 +48,15 @@ async function searchProducts() {
   searching.value = false
 }
 
-async function selectProduct(product: ProductHit) {
-  selectedProduct.value = product
-  query.value = product.name
+function addProduct(product: ProductHit) {
+  if (!addedIds.value.has(product.id)) products.value.push(product)
+  query.value = ''
   searchResults.value = []
-  await loadHistory(product.id)
 }
 
-async function loadHistory(productId: string) {
-  loadingHistory.value = true
-  history.value = []
-
-  const { data } = await supabase
-    .from('receipt_items')
-    .select(`
-      raw_name,
-      quantity,
-      unit_price,
-      units ( symbol ),
-      receipts!inner (
-        purchased_at,
-        currency,
-        stores!inner (
-          store_chains!inner ( name )
-        )
-      )
-    `)
-    .eq('canonical_product_id', productId)
-    .order('receipts(purchased_at)', { ascending: true })
-
-  if (data) {
-    history.value = data.map((row: any) => ({
-      date: row.receipts.purchased_at,
-      unit_price: row.unit_price,
-      store_chain: row.receipts.stores.store_chains.name,
-      raw_name: row.raw_name,
-      quantity: row.quantity,
-      item_unit: row.units?.symbol ?? '',
-      currency: row.receipts.currency
-    }))
-  }
-  loadingHistory.value = false
+function removeProduct(id: string) {
+  products.value = products.value.filter(p => p.id !== id)
 }
-
-const currencySymbol = computed(() => {
-  const c = history.value[0]?.currency ?? 'EUR'
-  return CURRENCY_SYMBOLS[c] ?? `${c} `
-})
-
-// Distinct units actually present across the receipt items for this product.
-const distinctUnits = computed(() =>
-  [...new Set(history.value.map(p => p.item_unit).filter(Boolean))]
-)
-
-// Prefer the canonical product's unit; fall back to the item unit only when unambiguous.
-const displayUnit = computed(() =>
-  selectedProduct.value?.unit ?? (distinctUnits.value.length === 1 ? distinctUnits.value[0]! : null)
-)
-
-// True when there's no canonical unit and items disagree — prices aren't comparable yet.
-const unitsMixed = computed(() =>
-  !selectedProduct.value?.unit && distinctUnits.value.length > 1
-)
-
-const yAxisLabel = computed(() =>
-  `Price (${currencySymbol.value}${displayUnit.value ? ` / ${displayUnit.value}` : ''})`
-)
-
-const chartData = computed(() => {
-  const chains = [...new Set(history.value.map(p => p.store_chain))]
-  return {
-    datasets: chains.map(chain => ({
-      label: chain,
-      data: history.value
-        .filter(p => p.store_chain === chain)
-        .map(p => ({ x: new Date(p.date).getTime(), y: p.unit_price, meta: p })),
-      borderColor: CHAIN_COLORS[chain] ?? '#94a3b8',
-      backgroundColor: (CHAIN_COLORS[chain] ?? '#94a3b8') + '33',
-      tension: 0.3,
-      pointRadius: 4,
-      pointHoverRadius: 6
-    }))
-  }
-})
-
-const chartOptions = computed(() => ({
-  responsive: true,
-  maintainAspectRatio: false,
-  interaction: { mode: 'nearest' as const, intersect: true },
-  scales: {
-    x: {
-      type: 'time' as const,
-      time: { unit: 'month' as const },
-      title: { display: true, text: 'Date' }
-    },
-    y: {
-      title: { display: true, text: yAxisLabel.value },
-      ticks: { callback: (v: any) => `${currencySymbol.value}${Number(v).toFixed(2)}` }
-    }
-  },
-  plugins: {
-    legend: { position: 'bottom' as const },
-    tooltip: {
-      callbacks: {
-        // Full original receipt name as the tooltip heading.
-        title: (items: any[]) => items[0]?.raw?.meta?.raw_name ?? '',
-        label: (ctx: any) => {
-          const m = ctx.raw.meta as PricePoint
-          const unit = displayUnit.value ?? m.item_unit
-          return `${ctx.dataset.label}: ${currencySymbol.value}${ctx.parsed.y.toFixed(2)}${unit ? ` / ${unit}` : ''}`
-        },
-        afterLabel: (ctx: any) => {
-          const m = ctx.raw.meta as PricePoint
-          const date = new Date(m.date).toLocaleDateString()
-          const qty = `Qty: ${m.quantity}${m.item_unit ? ` ${m.item_unit}` : ''}`
-          return [qty, date]
-        }
-      }
-    }
-  }
-}))
 </script>
 
 <template>
@@ -204,14 +66,14 @@ const chartOptions = computed(() => ({
         Price History
       </h1>
       <p class="text-muted text-sm">
-        Search for a product to see how its price has evolved across stores.
+        Add a chart per product to compare price trends across stores. Your charts are saved in this browser.
       </p>
     </div>
 
     <div class="relative mb-8">
       <UInput
         v-model="query"
-        placeholder="Search products… e.g. milk, eggs"
+        placeholder="Search products to add a chart… e.g. milk, eggs"
         icon="i-lucide-search"
         size="lg"
         class="w-full"
@@ -225,58 +87,35 @@ const chartOptions = computed(() => ({
         <button
           v-for="product in searchResults"
           :key="product.id"
-          class="w-full text-left px-4 py-2.5 hover:bg-elevated flex items-center gap-3 transition-colors"
-          @click="selectProduct(product)"
+          class="w-full text-left px-4 py-2.5 hover:bg-elevated flex items-center gap-3 transition-colors disabled:opacity-50"
+          :disabled="addedIds.has(product.id)"
+          @click="addProduct(product)"
         >
           <UIcon name="i-lucide-package" class="text-muted shrink-0" />
           <span>{{ product.name }}</span>
-          <span class="text-muted text-sm ml-auto">{{ product.short_name }}</span>
+          <span
+            v-if="addedIds.has(product.id)"
+            class="ml-auto text-xs text-primary flex items-center gap-1"
+          >
+            <UIcon name="i-lucide-check" /> added
+          </span>
+          <span v-else class="text-muted text-sm ml-auto">{{ product.short_name }}</span>
         </button>
       </div>
     </div>
 
-    <div v-if="loadingHistory" class="flex justify-center py-16">
-      <UIcon name="i-lucide-loader-circle" class="animate-spin text-3xl text-muted" />
+    <div v-if="products.length" class="space-y-6">
+      <ProductChart
+        v-for="product in products"
+        :key="product.id"
+        :product="product"
+        @remove="removeProduct(product.id)"
+      />
     </div>
 
-    <template v-else-if="selectedProduct && history.length">
-      <div class="mb-3 flex flex-wrap items-center gap-2">
-        <UBadge variant="subtle">
-          {{ history.length }} data points
-        </UBadge>
-        <span class="text-muted text-sm">for <strong>{{ selectedProduct.name }}</strong></span>
-        <UBadge
-          v-if="displayUnit && !unitsMixed"
-          color="neutral"
-          variant="outline"
-        >
-          {{ currencySymbol }} / {{ displayUnit }}
-        </UBadge>
-        <UBadge
-          v-if="unitsMixed"
-          color="warning"
-          variant="subtle"
-          icon="i-lucide-triangle-alert"
-        >
-          Mixed units: {{ distinctUnits.join(', ') }} — prices not comparable
-        </UBadge>
-      </div>
-      <div class="h-80 border border-default rounded-xl p-4 bg-background">
-        <Line :data="chartData" :options="chartOptions" />
-      </div>
-    </template>
-
-    <div
-      v-else-if="selectedProduct && !loadingHistory"
-      class="text-center py-16 text-muted"
-    >
-      <UIcon name="i-lucide-inbox" class="text-4xl mb-2" />
-      <p>No price history found for <strong>{{ selectedProduct.name }}</strong>.</p>
-    </div>
-
-    <div v-else-if="!selectedProduct" class="text-center py-16 text-muted">
-      <UIcon name="i-lucide-trending-up" class="text-4xl mb-2" />
-      <p>Search for a product above to see its price history.</p>
+    <div v-else class="text-center py-16 text-muted">
+      <UIcon name="i-lucide-line-chart" class="text-4xl mb-2" />
+      <p>Search for a product above to add your first chart.</p>
     </div>
   </UContainer>
 </template>

--- a/frontend/app/pages/prices.vue
+++ b/frontend/app/pages/prices.vue
@@ -65,6 +65,38 @@ function addProduct(product: ProductHit) {
 function removeProduct(id: string) {
   products.value = products.value.filter(p => p.id !== id)
 }
+
+// ── drag-and-drop reorder ───────────────────────────────────────────────
+// The card's grip handle is the only draggable element, so its native
+// dragstart bubbles here; the canvas stays non-draggable (box-zoom intact).
+const dragFromIndex = ref<number | null>(null)
+
+function onDragStart(i: number, e: DragEvent) {
+  dragFromIndex.value = i
+  if (e.dataTransfer) {
+    e.dataTransfer.effectAllowed = 'move'
+    const cell = (e.target as HTMLElement | null)?.closest('.chart-cell') as HTMLElement | null
+    if (cell) e.dataTransfer.setDragImage(cell, 24, 24)
+  }
+}
+
+function onDragOver(e: DragEvent) {
+  e.preventDefault()
+  if (e.dataTransfer) e.dataTransfer.dropEffect = 'move'
+}
+
+function onDrop(toIndex: number) {
+  const from = dragFromIndex.value
+  if (from === null || from === toIndex) return
+  const arr = [...products.value]
+  const [moved] = arr.splice(from, 1)
+  arr.splice(toIndex, 0, moved)
+  products.value = arr
+}
+
+function onDragEnd() {
+  dragFromIndex.value = null
+}
 </script>
 
 <template>
@@ -74,7 +106,7 @@ function removeProduct(id: string) {
         Price History
       </h1>
       <p class="text-muted text-sm">
-        Add a chart per product to compare price trends across stores. Your layout is saved in this browser.
+        Add a chart per product to compare price trends across stores. Drag the grip to reorder; your layout is saved in this browser.
       </p>
     </div>
 
@@ -132,12 +164,21 @@ function removeProduct(id: string) {
       class="grid gap-6"
       :style="{ gridTemplateColumns: `repeat(${perRow}, minmax(0, 1fr))` }"
     >
-      <ProductChart
-        v-for="product in products"
+      <div
+        v-for="(product, i) in products"
         :key="product.id"
-        :product="product"
-        @remove="removeProduct(product.id)"
-      />
+        class="chart-cell transition-opacity"
+        :class="{ 'opacity-40': dragFromIndex === i }"
+        @dragstart="onDragStart(i, $event)"
+        @dragend="onDragEnd"
+        @dragover="onDragOver"
+        @drop="onDrop(i)"
+      >
+        <ProductChart
+          :product="product"
+          @remove="removeProduct(product.id)"
+        />
+      </div>
     </div>
 
     <div v-else class="text-center py-16 text-muted">

--- a/frontend/app/pages/products.vue
+++ b/frontend/app/pages/products.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+useSeoMeta({ title: 'Products · cartwatch' })
+</script>
+
+<template>
+  <UContainer class="py-8 max-w-7xl">
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold mb-1">
+        Products
+      </h1>
+      <p class="text-muted text-sm">
+        Every canonical product with how often it's been observed and its price statistics across stores.
+      </p>
+    </div>
+
+    <ProductStatsTable />
+  </UContainer>
+</template>

--- a/frontend/app/types/database.types.ts
+++ b/frontend/app/types/database.types.ts
@@ -1,0 +1,571 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.1"
+  }
+  public: {
+    Tables: {
+      canonical_product_drafts: {
+        Row: {
+          created_at: string
+          id: string
+          llm_reasoning: string | null
+          reviewed_at: string | null
+          source_item_ids: string[]
+          status: string
+          suggested_category: string | null
+          suggested_name: string
+          suggested_short_name: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          llm_reasoning?: string | null
+          reviewed_at?: string | null
+          source_item_ids: string[]
+          status?: string
+          suggested_category?: string | null
+          suggested_name: string
+          suggested_short_name?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          llm_reasoning?: string | null
+          reviewed_at?: string | null
+          source_item_ids?: string[]
+          status?: string
+          suggested_category?: string | null
+          suggested_name?: string
+          suggested_short_name?: string | null
+        }
+        Relationships: []
+      }
+      canonical_products: {
+        Row: {
+          barcode: string | null
+          category_id: string | null
+          created_at: string
+          embedding: string | null
+          id: string
+          name: string
+          short_name: string
+          unit_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          barcode?: string | null
+          category_id?: string | null
+          created_at?: string
+          embedding?: string | null
+          id?: string
+          name: string
+          short_name: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          barcode?: string | null
+          category_id?: string | null
+          created_at?: string
+          embedding?: string | null
+          id?: string
+          name?: string
+          short_name?: string
+          unit_id?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "canonical_products_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "canonical_products_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "units"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      categories: {
+        Row: {
+          id: string
+          name: string
+          parent_id: string | null
+        }
+        Insert: {
+          id?: string
+          name: string
+          parent_id?: string | null
+        }
+        Update: {
+          id?: string
+          name?: string
+          parent_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "categories_parent_id_fkey"
+            columns: ["parent_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      product_matches: {
+        Row: {
+          canonical_product_id: string | null
+          confidence: number
+          created_at: string
+          id: string
+          matched_by: string | null
+          receipt_item_id: string
+          reviewed_at: string | null
+          status: Database["public"]["Enums"]["match_status"]
+        }
+        Insert: {
+          canonical_product_id?: string | null
+          confidence: number
+          created_at?: string
+          id?: string
+          matched_by?: string | null
+          receipt_item_id: string
+          reviewed_at?: string | null
+          status?: Database["public"]["Enums"]["match_status"]
+        }
+        Update: {
+          canonical_product_id?: string | null
+          confidence?: number
+          created_at?: string
+          id?: string
+          matched_by?: string | null
+          receipt_item_id?: string
+          reviewed_at?: string | null
+          status?: Database["public"]["Enums"]["match_status"]
+        }
+        Relationships: [
+          {
+            foreignKeyName: "product_matches_canonical_product_id_fkey"
+            columns: ["canonical_product_id"]
+            isOneToOne: false
+            referencedRelation: "canonical_products"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "product_matches_receipt_item_id_fkey"
+            columns: ["receipt_item_id"]
+            isOneToOne: true
+            referencedRelation: "receipt_items"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      receipt_items: {
+        Row: {
+          canonical_product_id: string | null
+          created_at: string
+          discount: number | null
+          id: string
+          ignore: boolean | null
+          quantity: number
+          raw_name: string
+          receipt_id: string
+          short_name: string | null
+          tax_rate: number | null
+          total_price: number
+          unit_id: string | null
+          unit_price: number
+          user_id: string
+        }
+        Insert: {
+          canonical_product_id?: string | null
+          created_at?: string
+          discount?: number | null
+          id?: string
+          ignore?: boolean | null
+          quantity: number
+          raw_name: string
+          receipt_id: string
+          short_name?: string | null
+          tax_rate?: number | null
+          total_price: number
+          unit_id?: string | null
+          unit_price: number
+          user_id: string
+        }
+        Update: {
+          canonical_product_id?: string | null
+          created_at?: string
+          discount?: number | null
+          id?: string
+          ignore?: boolean | null
+          quantity?: number
+          raw_name?: string
+          receipt_id?: string
+          short_name?: string | null
+          tax_rate?: number | null
+          total_price?: number
+          unit_id?: string | null
+          unit_price?: number
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "receipt_items_canonical_product_id_fkey"
+            columns: ["canonical_product_id"]
+            isOneToOne: false
+            referencedRelation: "canonical_products"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "receipt_items_receipt_id_fkey"
+            columns: ["receipt_id"]
+            isOneToOne: false
+            referencedRelation: "receipts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "receipt_items_unit_id_fkey"
+            columns: ["unit_id"]
+            isOneToOne: false
+            referencedRelation: "units"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      receipt_sources: {
+        Row: {
+          created_at: string
+          external_id: string | null
+          id: string
+          pdf_urls: string[] | null
+          raw_html: string | null
+          raw_text: string | null
+          receipt_id: string | null
+          source_type: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          pdf_urls?: string[] | null
+          raw_html?: string | null
+          raw_text?: string | null
+          receipt_id?: string | null
+          source_type: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          external_id?: string | null
+          id?: string
+          pdf_urls?: string[] | null
+          raw_html?: string | null
+          raw_text?: string | null
+          receipt_id?: string | null
+          source_type?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "receipt_sources_receipt_id_fkey"
+            columns: ["receipt_id"]
+            isOneToOne: false
+            referencedRelation: "receipts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      receipts: {
+        Row: {
+          created_at: string
+          currency: string
+          id: string
+          payment_method: string | null
+          purchased_at: string
+          store_id: string | null
+          subtotal: number | null
+          tax_total: number | null
+          total: number
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          currency?: string
+          id?: string
+          payment_method?: string | null
+          purchased_at: string
+          store_id?: string | null
+          subtotal?: number | null
+          tax_total?: number | null
+          total: number
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          currency?: string
+          id?: string
+          payment_method?: string | null
+          purchased_at?: string
+          store_id?: string | null
+          subtotal?: number | null
+          tax_total?: number | null
+          total?: number
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "receipts_store_id_fkey"
+            columns: ["store_id"]
+            isOneToOne: false
+            referencedRelation: "stores"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      store_chains: {
+        Row: {
+          country: string
+          id: string
+          logo_url: string | null
+          name: string
+        }
+        Insert: {
+          country?: string
+          id?: string
+          logo_url?: string | null
+          name: string
+        }
+        Update: {
+          country?: string
+          id?: string
+          logo_url?: string | null
+          name?: string
+        }
+        Relationships: []
+      }
+      stores: {
+        Row: {
+          address: string | null
+          chain_id: string | null
+          city: string | null
+          country: string
+          created_at: string
+          id: string
+          ignore: boolean | null
+          name: string
+          postal_code: string | null
+          user_id: string
+        }
+        Insert: {
+          address?: string | null
+          chain_id?: string | null
+          city?: string | null
+          country?: string
+          created_at?: string
+          id?: string
+          ignore?: boolean | null
+          name: string
+          postal_code?: string | null
+          user_id: string
+        }
+        Update: {
+          address?: string | null
+          chain_id?: string | null
+          city?: string | null
+          country?: string
+          created_at?: string
+          id?: string
+          ignore?: boolean | null
+          name?: string
+          postal_code?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "stores_chain_id_fkey"
+            columns: ["chain_id"]
+            isOneToOne: false
+            referencedRelation: "store_chains"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      units: {
+        Row: {
+          id: string
+          name: string
+          quantity: string
+          symbol: string
+        }
+        Insert: {
+          id?: string
+          name: string
+          quantity: string
+          symbol: string
+        }
+        Update: {
+          id?: string
+          name?: string
+          quantity?: string
+          symbol?: string
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      show_limit: { Args: never; Returns: number }
+      show_trgm: { Args: { "": string }; Returns: string[] }
+    }
+    Enums: {
+      match_status: "pending" | "confirmed" | "rejected"
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  public: {
+    Enums: {
+      match_status: ["pending", "confirmed", "rejected"],
+    },
+  },
+} as const

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -2,7 +2,8 @@
 export default defineNuxtConfig({
   modules: [
     '@nuxt/eslint',
-    '@nuxt/ui'
+    '@nuxt/ui',
+    '@nuxtjs/supabase'
   ],
 
   devtools: {
@@ -11,8 +12,8 @@ export default defineNuxtConfig({
 
   css: ['~/assets/css/main.css'],
 
-  routeRules: {
-    '/': { prerender: true }
+  supabase: {
+    redirect: false
   },
 
   compatibilityDate: '2025-01-15',

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -16,6 +16,12 @@ export default defineNuxtConfig({
     redirect: false
   },
 
+  // The dashboard is client-side (anon data, localStorage, Chart.js zoom plugin
+  // touches `window` at import) — render it as an SPA route.
+  routeRules: {
+    '/prices': { ssr: false }
+  },
+
   compatibilityDate: '2025-01-15',
 
   eslint: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@supabase/supabase-js": "^2.108.2",
     "chart.js": "^4.5.1",
     "chartjs-adapter-date-fns": "^3.0.0",
+    "chartjs-plugin-zoom": "^2.2.0",
     "date-fns": "^4.4.0",
     "nuxt": "^4.3.1",
     "tailwindcss": "^4.1.18",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,14 @@
     "@iconify-json/lucide": "^1.2.90",
     "@iconify-json/simple-icons": "^1.2.70",
     "@nuxt/ui": "^4.4.0",
+    "@nuxtjs/supabase": "^2.0.9",
+    "@supabase/supabase-js": "^2.108.2",
+    "chart.js": "^4.5.1",
+    "chartjs-adapter-date-fns": "^3.0.0",
+    "date-fns": "^4.4.0",
     "nuxt": "^4.3.1",
-    "tailwindcss": "^4.1.18"
+    "tailwindcss": "^4.1.18",
+    "vue-chartjs": "^5.3.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.4.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,12 +17,30 @@ importers:
       '@nuxt/ui':
         specifier: ^4.4.0
         version: 4.4.0(@tiptap/extensions@3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.9.3)(magicast@0.5.2)(tailwindcss@4.1.18)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3))(yjs@13.6.29)
+      '@nuxtjs/supabase':
+        specifier: ^2.0.9
+        version: 2.0.9
+      '@supabase/supabase-js':
+        specifier: ^2.108.2
+        version: 2.108.2
+      chart.js:
+        specifier: ^4.5.1
+        version: 4.5.1
+      chartjs-adapter-date-fns:
+        specifier: ^3.0.0
+        version: 3.0.0(chart.js@4.5.1)(date-fns@4.4.0)
+      date-fns:
+        specifier: ^4.4.0
+        version: 4.4.0
       nuxt:
         specifier: ^4.3.1
         version: 4.3.1(@parcel/watcher@2.5.6)(@types/node@25.3.2)(@vue/compiler-sfc@3.5.28)(cac@6.7.14)(db0@0.3.4)(eslint@10.0.0(jiti@2.6.1))(ioredis@5.9.3)(lightningcss@1.31.1)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rollup@4.57.1)(terser@5.46.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))(vue-tsc@3.2.4(typescript@5.9.3))(yaml@2.8.2)
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
+      vue-chartjs:
+        specifier: ^5.3.3
+        version: 5.3.3(chart.js@4.5.1)(vue@3.5.28(typescript@5.9.3))
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.4.2
@@ -753,6 +771,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@kurkle/color@0.3.4':
+    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
+
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
@@ -917,6 +938,9 @@ packages:
 
   '@nuxtjs/color-mode@3.5.2':
     resolution: {integrity: sha512-cC6RfgZh3guHBMLLjrBB2Uti5eUoGM9KyauOaYS9ETmxNWBMTvpgjvSiSJp1OFljIXPIqVTJ3xtJpSNZiO3ZaA==}
+
+  '@nuxtjs/supabase@2.0.9':
+    resolution: {integrity: sha512-nDPslxt/Af5ya21m19rcb0kwZeAYVcvfw3VOxiViZuW0OFL0Xmi+kowSoqXnyuNJKEesvmXZKBV0rwh0FSERHg==}
 
   '@oxc-minify/binding-android-arm-eabi@0.112.0':
     resolution: {integrity: sha512-m7TGBR2hjsBJIN9UJ909KBoKsuogo6CuLsHKvUIBXdjI0JVHP8g4ZHeB+BJpGn5LJdeSGDfz9MWiuXrZDRzunw==}
@@ -1654,6 +1678,38 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=9.0.0'
+
+  '@supabase/auth-js@2.108.2':
+    resolution: {integrity: sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.108.2':
+    resolution: {integrity: sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.4':
+    resolution: {integrity: sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==}
+
+  '@supabase/postgrest-js@2.108.2':
+    resolution: {integrity: sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.108.2':
+    resolution: {integrity: sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/ssr@0.10.3':
+    resolution: {integrity: sha512-ux2CJgX89h0Fz2lY7ZNafNG2SkXpyRc5dz77K9eKeBLPdtywQixKwIuetDeIViAJBp/buOUVmgj8PVesOklNpw==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.105.3
+
+  '@supabase/storage-js@2.108.2':
+    resolution: {integrity: sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.108.2':
+    resolution: {integrity: sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==}
+    engines: {node: '>=20.0.0'}
 
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
@@ -2575,6 +2631,16 @@ packages:
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
 
+  chart.js@4.5.1:
+    resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
+    engines: {pnpm: '>=8'}
+
+  chartjs-adapter-date-fns@3.0.0:
+    resolution: {integrity: sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==}
+    peerDependencies:
+      chart.js: '>=2.8.0'
+      date-fns: '>=2.0.0'
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -2686,6 +2752,10 @@ packages:
   cookie-es@2.0.0:
     resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
@@ -2794,6 +2864,9 @@ packages:
     resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
     engines: {node: '>=12'}
 
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
   db0@0.3.4:
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
     peerDependencies:
@@ -2851,6 +2924,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
@@ -3415,6 +3491,10 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -5252,6 +5332,12 @@ packages:
   vue-bundle-renderer@2.2.0:
     resolution: {integrity: sha512-sz/0WEdYH1KfaOm0XaBmRZOWgYTEvUDt6yPYaUzl4E52qzgWLlknaPPTTZmp6benaPTlQAI/hN1x3tAzZygycg==}
 
+  vue-chartjs@5.3.3:
+    resolution: {integrity: sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==}
+    peerDependencies:
+      chart.js: ^4.1.1
+      vue: ^3.0.0-0 || ^2.7.0
+
   vue-component-type-helpers@3.2.4:
     resolution: {integrity: sha512-05lR16HeZDcDpB23ku5b5f1fBOoHqFnMiKRr2CiEvbG5Ux4Yi0McmQBOET0dR0nxDXosxyVqv67q6CzS3AK8rw==}
 
@@ -6077,6 +6163,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@kurkle/color@0.3.4': {}
+
   '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3
@@ -6671,6 +6759,13 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@nuxtjs/supabase@2.0.9':
+    dependencies:
+      '@supabase/ssr': 0.10.3(@supabase/supabase-js@2.108.2)
+      '@supabase/supabase-js': 2.108.2
+      defu: 6.1.7
+      pathe: 2.0.3
+
   '@oxc-minify/binding-android-arm-eabi@0.112.0':
     optional: true
 
@@ -7104,6 +7199,43 @@ snapshots:
       espree: 10.4.0
       estraverse: 5.3.0
       picomatch: 4.0.3
+
+  '@supabase/auth-js@2.108.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.108.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.4': {}
+
+  '@supabase/postgrest-js@2.108.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.108.2':
+    dependencies:
+      '@supabase/phoenix': 0.4.4
+      tslib: 2.8.1
+
+  '@supabase/ssr@0.10.3(@supabase/supabase-js@2.108.2)':
+    dependencies:
+      '@supabase/supabase-js': 2.108.2
+      cookie: 1.1.1
+
+  '@supabase/storage-js@2.108.2':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.108.2':
+    dependencies:
+      '@supabase/auth-js': 2.108.2
+      '@supabase/functions-js': 2.108.2
+      '@supabase/postgrest-js': 2.108.2
+      '@supabase/realtime-js': 2.108.2
+      '@supabase/storage-js': 2.108.2
 
   '@swc/helpers@0.5.18':
     dependencies:
@@ -8060,6 +8192,15 @@ snapshots:
 
   change-case@5.4.4: {}
 
+  chart.js@4.5.1:
+    dependencies:
+      '@kurkle/color': 0.3.4
+
+  chartjs-adapter-date-fns@3.0.0(chart.js@4.5.1)(date-fns@4.4.0):
+    dependencies:
+      chart.js: 4.5.1
+      date-fns: 4.4.0
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -8154,6 +8295,8 @@ snapshots:
   cookie-es@1.2.2: {}
 
   cookie-es@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   copy-anything@4.0.5:
     dependencies:
@@ -8284,6 +8427,8 @@ snapshots:
 
   dargs@8.1.0: {}
 
+  date-fns@4.4.0: {}
+
   db0@0.3.4: {}
 
   debug@4.4.3:
@@ -8306,6 +8451,8 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   defu@6.1.4: {}
+
+  defu@6.1.7: {}
 
   denque@2.1.0: {}
 
@@ -8975,6 +9122,8 @@ snapshots:
   httpxy@0.1.7: {}
 
   human-signals@5.0.0: {}
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.4.24:
     dependencies:
@@ -10990,6 +11139,11 @@ snapshots:
   vue-bundle-renderer@2.2.0:
     dependencies:
       ufo: 1.6.3
+
+  vue-chartjs@5.3.3(chart.js@4.5.1)(vue@3.5.28(typescript@5.9.3)):
+    dependencies:
+      chart.js: 4.5.1
+      vue: 3.5.28(typescript@5.9.3)
 
   vue-component-type-helpers@3.2.4: {}
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       chartjs-adapter-date-fns:
         specifier: ^3.0.0
         version: 3.0.0(chart.js@4.5.1)(date-fns@4.4.0)
+      chartjs-plugin-zoom:
+        specifier: ^2.2.0
+        version: 2.2.0(chart.js@4.5.1)
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -2055,6 +2058,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hammerjs@2.0.46':
+    resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -2640,6 +2646,11 @@ packages:
     peerDependencies:
       chart.js: '>=2.8.0'
       date-fns: '>=2.0.0'
+
+  chartjs-plugin-zoom@2.2.0:
+    resolution: {integrity: sha512-in6kcdiTlP6npIVLMd4zXZ08PDUXC52gZ4FAy5oyjk1zX3gKarXMAof7B9eFiisf9WOC3bh2saHg+J5WtLXZeA==}
+    peerDependencies:
+      chart.js: '>=3.2.0'
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -3456,6 +3467,10 @@ packages:
 
   h3@1.15.5:
     resolution: {integrity: sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==}
+
+  hammerjs@2.0.8:
+    resolution: {integrity: sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==}
+    engines: {node: '>=0.8.0'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -7570,6 +7585,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/hammerjs@2.0.46': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/linkify-it@5.0.0': {}
@@ -8200,6 +8217,12 @@ snapshots:
     dependencies:
       chart.js: 4.5.1
       date-fns: 4.4.0
+
+  chartjs-plugin-zoom@2.2.0(chart.js@4.5.1):
+    dependencies:
+      '@types/hammerjs': 2.0.46
+      chart.js: 4.5.1
+      hammerjs: 2.0.8
 
   chokidar@4.0.3:
     dependencies:
@@ -9089,6 +9112,8 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.3
       uncrypto: 0.1.3
+
+  hammerjs@2.0.8: {}
 
   hasown@2.0.2:
     dependencies:

--- a/frontend/scripts/query.mjs
+++ b/frontend/scripts/query.mjs
@@ -1,0 +1,47 @@
+// Ad-hoc Supabase query runner for debugging.
+//
+// Usage:
+//   node scripts/query.mjs              # uses anon key (what the frontend uses)
+//   node scripts/query.mjs --service    # uses service key (bypasses RLS)
+//
+// Edit the query at the bottom and re-run. Reads credentials from frontend/.env.
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { createClient } from '@supabase/supabase-js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+function loadEnv() {
+  const raw = readFileSync(join(__dirname, '..', '.env'), 'utf8')
+  const env = {}
+  for (const line of raw.split('\n')) {
+    const m = line.match(/^\s*([\w.-]+)\s*=\s*(.*)\s*$/)
+    if (m && !line.trim().startsWith('#')) env[m[1]] = m[2]
+  }
+  return env
+}
+
+const env = loadEnv()
+const useService = process.argv.includes('--service')
+const url = env.SUPABASE_URL
+const key = useService ? env.SUPABASE_SERVICE_KEY_DEBUG : env.SUPABASE_KEY
+
+if (!url || !key) {
+  console.error(`Missing ${useService ? 'SUPABASE_SERVICE_KEY_DEBUG' : 'SUPABASE_KEY'} or SUPABASE_URL in .env`)
+  process.exit(1)
+}
+
+const sb = createClient(url, key)
+console.log(`→ ${url}  (${useService ? 'service_role' : 'anon'})\n`)
+
+// ─── edit your query here ─────────────────────────────────────────────
+// Example: the exact join the /prices page runs for one product.
+const { data, error } = await sb
+  .from('canonical_products')
+  .select('id, name, short_name')
+  .ilike('name', '%milk%')
+  .limit(10)
+// ──────────────────────────────────────────────────────────────────────
+
+console.log(JSON.stringify({ count: data?.length, data, error }, null, 2))


### PR DESCRIPTION
## Summary

Builds out the cartwatch frontend (Nuxt UI v4) — the "basic dashboard" from the V1 roadmap — reading the user's real receipt data straight from Supabase with the anon client. Three pages:

- **Price History** (`/prices`) — one chart per canonical product, price over time across store chains. Raw observations as dots, plus a smooth **monthly-median** line. Left filters sidebar (search, min-observations, jitter, charts-per-row). Charts persist in `localStorage`, can be reordered by drag, and laid out 1–3 per row.
- **Products** (`/products`) — sortable, filterable table from `mv_product_stats`: observations, receipts, retailers, per-unit median/min/max, total spend. Unit filter (kg / L / piece).
- **Data Quality** (`/data-quality`) — collapsible checks that surface real issues (unmatched items, mixed units, invalid prices, receipt-total mismatches, pending matches, missing units/categories, …) with drill-down tables.

## Chart interactions

- **Zoom**: mouse-wheel, +/- buttons, and box-zoom that picks the axis from the drag shape (wide → X, tall → Y, square → both).
- **Pan**: shift-drag, with grab/grabbing cursors.
- **Double-click** to reset.
- Search dropdown lists the most-tracked products first and supports arrow-key / Enter / Tab / Esc navigation.

## Data access

- Uses `@nuxtjs/supabase` with the **anon key**, querying tables/views directly (no backend roundtrip for reads). Generated `database.types.ts` for typed queries.
- `/prices` is rendered client-side (`ssr: false`) because `chartjs-plugin-zoom` touches `window` at import.
- Added `scripts/query.mjs` for ad-hoc Supabase queries while debugging.

## ⚠️ Reviewer note — auth / RLS

To get reads working for a single user without wiring auth yet, the **live DB currently has RLS disabled and blanket anon read grants**. This diverges from the repo migrations (which enable RLS) and must be revisited before this is multi-user or public — the frontend reads everything with the anon key. Auth (a login page so RLS can scope to the owner) is the natural next step.

## Status

Several commits are `wip` — the price-history line aggregation and box-zoom were tuned iteratively. Fine to **squash-merge**. Not yet included / next up (per roadmap): a global time-range filter, an overview/KPI page, spending-over-time, retailer comparison, and a personal inflation index — most of which get better once the data-modeling items (unit normalization, store dedup, category assignment) land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
